### PR TITLE
Add 28" preset, edit rotated signs in visual orientation, cap preview height

### DIFF
--- a/components/DeviceEditor.tsx
+++ b/components/DeviceEditor.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { Block, DeviceDoc, AssetDoc } from "@/lib/mongo";
+import { editorDims } from "@/lib/dims";
 import LayoutEditor from "./LayoutEditor";
 
 type Props = {
@@ -86,11 +87,20 @@ export default function DeviceEditor({ device, assets }: Props) {
         </div>
       </div>
 
-      <div className="grid grid-cols-[1fr_360px] gap-4">
+      {(() => {
+        const { w: editW, h: editH } = editorDims({ width, height, rotation });
+        const rotated = rotation === 90 || rotation === 270;
+        return (
+        <div className="grid grid-cols-[1fr_360px] gap-4">
         <div>
+          {rotated && (
+            <p className="text-xs text-neutral-500 mb-2">
+              Rotated mount ({rotation}°): editing at {editW}×{editH}; saved image is rotated to the device's native {width}×{height}.
+            </p>
+          )}
           <LayoutEditor
-            width={width}
-            height={height}
+            width={editW}
+            height={editH}
             initialLayout={layout}
             assets={assets}
             onChange={setLayout}
@@ -99,14 +109,14 @@ export default function DeviceEditor({ device, assets }: Props) {
         <aside className="space-y-3">
           <div className="card">
             <h4 className="font-medium mb-2">Rendered preview (1-bit)</h4>
-            <div className="bg-white border border-neutral-700">
+            <div className="bg-white border border-neutral-700 max-h-[420px] overflow-hidden flex items-center justify-center">
               <img
                 src={`/api/devices/${device._id}/render?format=png&t=${previewBust}`}
                 alt=""
-                className="w-full h-auto pixelated"
+                className="max-w-full max-h-[420px] w-auto h-auto pixelated object-contain"
               />
             </div>
-            <p className="text-xs text-neutral-500 mt-2">Shows the actual 1-bit output. Click <em>Save</em> to refresh.</p>
+            <p className="text-xs text-neutral-500 mt-2">Shows the actual 1-bit output ({width}×{height}). Click <em>Save</em> to refresh.</p>
             <button className="btn w-full mt-2" onClick={() => setPreviewBust(Date.now())}>Refresh preview</button>
           </div>
 
@@ -120,6 +130,8 @@ export default function DeviceEditor({ device, assets }: Props) {
           </div>
         </aside>
       </div>
+        );
+      })()}
     </div>
   );
 }

--- a/lib/dims.ts
+++ b/lib/dims.ts
@@ -1,0 +1,9 @@
+// Editor / device dimension helper.
+// device.width × device.height is the device's native buffer size. When a
+// rotation is in effect the layout is authored in the visually-rotated frame,
+// so the editor canvas swaps dimensions while the device output stays native.
+export function editorDims(d: { width: number; height: number; rotation?: number | null }): { w: number; h: number } {
+  return d.rotation === 90 || d.rotation === 270
+    ? { w: d.height, h: d.width }
+    : { w: d.width, h: d.height };
+}

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -6,6 +6,7 @@ import { encodeBmp1bit, rgbaTo1Bit } from "./bmp";
 import { ensureFontsRegistered, fontString } from "./fonts";
 import { renderQr } from "./qr";
 import { abbreviateDay, dayOfMonth, formatTimeParts, monthName, parseFlexible } from "./dates";
+import { editorDims } from "./dims";
 
 // ---- Rendering pipeline ----
 // 1) Draw everything onto an RGBA canvas at device pixel size.
@@ -23,7 +24,12 @@ export async function renderDevice(
   opts: RenderOptions = {}
 ): Promise<{ pixels1: Uint8Array; rgba: Uint8ClampedArray; width: number; height: number; bmp: Buffer }> {
   ensureFontsRegistered();
-  const canvas = createCanvas(device.width, device.height);
+  // Layout is authored in the editor's visual frame: when the device is
+  // mounted with a 90°/270° rotation, the user designs at the swapped
+  // dimensions. We draw the canvas at the editor frame, then rotate the
+  // pixels so the device buffer matches the stored native width/height.
+  const { w: editW, h: editH } = editorDims(device);
+  const canvas = createCanvas(editW, editH);
   const ctx = canvas.getContext("2d") as SKRSContext2D;
   // @ts-ignore
   ctx.imageSmoothingEnabled = false;
@@ -32,23 +38,23 @@ export async function renderDevice(
 
   const defaultBg = device.background ?? "white";
   ctx.fillStyle = defaultBg === "black" ? "#000000" : "#ffffff";
-  ctx.fillRect(0, 0, device.width, device.height);
+  ctx.fillRect(0, 0, editW, editH);
 
   for (const block of device.layout) {
     await drawBlock(ctx, block, assetMap, { defaultBg });
   }
 
-  const rgba = ctx.getImageData(0, 0, device.width, device.height).data;
-  const pixels1 = rgbaTo1Bit(rgba, device.width, device.height, {
+  const rgba = ctx.getImageData(0, 0, editW, editH).data;
+  const pixels1 = rgbaTo1Bit(rgba, editW, editH, {
     mode: opts.dither ? "dither" : "threshold",
     threshold: opts.threshold ?? 160,
   });
 
-  let outW = device.width;
-  let outH = device.height;
+  let outW = editW;
+  let outH = editH;
   let outPixels = pixels1;
   if (device.rotation) {
-    const r = rotatePixels(pixels1, device.width, device.height, device.rotation);
+    const r = rotatePixels(pixels1, editW, editH, device.rotation);
     outPixels = r.pixels;
     outW = r.width;
     outH = r.height;
@@ -57,6 +63,7 @@ export async function renderDevice(
   const bmp = encodeBmp1bit(outW, outH, outPixels);
   return { pixels1: outPixels, rgba, width: outW, height: outH, bmp };
 }
+
 
 function rotatePixels(pixels: Uint8Array, w: number, h: number, deg: number) {
   if (deg === 180) {


### PR DESCRIPTION
## Summary

- Add a **28" 16-bit greyscale (3840×1080)** option to the device-creation screen-size dropdown.
- When a device has a 90°/270° rotation, the layout editor now shows the canvas in its **visual** (rotated) orientation. The renderer draws blocks in that editor frame and rotates the final pixels back to the device's stored native `width × height`, so the BMP/PNG the device fetches keeps its original buffer size.
- Cap the rendered-preview card on the device editor to ~420px tall with `object-contain`, so tall/wide signs no longer require scrolling to see the full preview.

## Why

Designing a rotated sign in the un-rotated buffer orientation is awkward — you mentally have to flip everything. Now the editor matches what you'll see on the mounted display, while the device still receives a buffer in its native size.

## Implementation notes

- New helper `editorDims()` in [lib/dims.ts](lib/dims.ts) — pure function, safe to import from both client and server.
- Storage convention: `device.width × device.height` = device's native buffer (what gets sent to hardware). Block `x/y/w/h` are stored in the editor (visual/rotated) frame.
- Heads-up for existing devices: if any device already had `rotation` set to 90/270 with blocks authored in the pre-change frame, those layouts will need to be re-positioned. Devices with rotation=0 are unaffected.

## Test plan

- [ ] Create a new device with the 28" preset; confirm it appears in the dropdown and populates 3840×1080.
- [ ] Set rotation to 90° on a device; confirm the LayoutEditor swaps to display the rotated dimensions and the helper note appears.
- [ ] Place a block in the rotated editor, save, fetch `/{slug}/current.bmp`, and confirm the returned image is at the device's native width×height.
- [ ] On a tall device (e.g. 1080×3840 or the 28" preset), confirm the rendered-preview card no longer requires scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)