### PR TITLE
Scale layout editor by both axes so tall signs fit on one page

### DIFF
--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -15,7 +15,8 @@ type Props = {
 };
 
 const SNAP = 2;
-const MAX_DISPLAY = 900;
+const MAX_DISPLAY_W = 900;
+const MAX_DISPLAY_H = 700;
 
 export default function LayoutEditor({ width, height, initialLayout, assets, onChange }: Props) {
   const [blocks, setBlocks] = useState<Block[]>(initialLayout);
@@ -26,7 +27,10 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
 
   useEffect(() => { onChange(blocks); /* eslint-disable-next-line */ }, [blocks]);
 
-  const scale = useMemo(() => Math.min(1, MAX_DISPLAY / width), [width]);
+  const scale = useMemo(
+    () => Math.min(1, MAX_DISPLAY_W / width, MAX_DISPLAY_H / height),
+    [width, height]
+  );
   const selectedBlock = blocks.find((b) => b.id === selected) ?? null;
 
   function update(id: string, patch: Partial<Block>) {


### PR DESCRIPTION
## Summary

The layout editor previously scaled only by width (`MAX_DISPLAY = 900`), which left tall canvases overflowing the page. For example, a vertically-rotated 28" sign at 1080×3840 px would render the editor at ~3200 px tall — well past one screen.

Add a separate height cap (`MAX_DISPLAY_H = 700`) and compute `scale = min(1, 900/width, 700/height)` so the tighter axis wins. The whole canvas now stays visible without scrolling regardless of orientation.

## Test plan

- [ ] Open a wide device (e.g. 800×480) — editor still scales by width, looks unchanged.
- [ ] Open a tall device (e.g. 1080×3840 from the rotated 28" preset) — editor canvas fits within ~700px tall, fully visible without page scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)