### PR TITLE
Add 24-bit BGR BMP output for controllers that reject 1-bpp input

### DIFF
--- a/app/[slug]/current.png/route.ts
+++ b/app/[slug]/current.png/route.ts
@@ -9,13 +9,17 @@ export async function GET(_req: NextRequest, { params }: { params: { slug: strin
   const doc = await col.findOne({ slug: params.slug });
   if (!doc) return new NextResponse("not found", { status: 404 });
   const assetMap = await loadAssetMap(doc);
-  const { pixels1, width, height } = await renderDevice(doc, assetMap);
+  const { pixels1, rgba, width, height } = await renderDevice(doc, assetMap);
   const canvas = createCanvas(width, height);
   const ctx = canvas.getContext("2d");
   const img = ctx.createImageData(width, height);
-  for (let i = 0, p = 0; i < pixels1.length; i++, p += 4) {
-    const v = pixels1[i] ? 255 : 0;
-    img.data[p] = v; img.data[p + 1] = v; img.data[p + 2] = v; img.data[p + 3] = 255;
+  if (doc.bitDepth === 24) {
+    img.data.set(rgba);
+  } else {
+    for (let i = 0, p = 0; i < pixels1.length; i++, p += 4) {
+      const v = pixels1[i] ? 255 : 0;
+      img.data[p] = v; img.data[p + 1] = v; img.data[p + 2] = v; img.data[p + 3] = 255;
+    }
   }
   ctx.putImageData(img, 0, 0);
   const png = await canvas.encode("png");

--- a/app/api/devices/[id]/render/route.ts
+++ b/app/api/devices/[id]/render/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   if (!doc) return NextResponse.json({ error: "not found" }, { status: 404 });
 
   const assetMap = await loadAssetMap(doc);
-  const { bmp, pixels1, width, height } = await renderDevice(doc, assetMap, { dither, threshold });
+  const { bmp, pixels1, rgba, width, height } = await renderDevice(doc, assetMap, { dither, threshold });
 
   if (format === "bmp") {
     return new NextResponse(new Uint8Array(bmp), {
@@ -23,13 +23,18 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     });
   }
 
-  // Render the 1-bit buffer back to a PNG so the preview matches the device output byte-for-byte.
+  // Preview matches the actual device output: for 1-bit devices show the
+  // thresholded buffer; for 24-bit devices show the full-colour rgba.
   const canvas = createCanvas(width, height);
   const ctx = canvas.getContext("2d");
   const img = ctx.createImageData(width, height);
-  for (let i = 0, p = 0; i < pixels1.length; i++, p += 4) {
-    const v = pixels1[i] ? 255 : 0;
-    img.data[p] = v; img.data[p + 1] = v; img.data[p + 2] = v; img.data[p + 3] = 255;
+  if (doc.bitDepth === 24) {
+    img.data.set(rgba);
+  } else {
+    for (let i = 0, p = 0; i < pixels1.length; i++, p += 4) {
+      const v = pixels1[i] ? 255 : 0;
+      img.data[p] = v; img.data[p + 1] = v; img.data[p + 2] = v; img.data[p + 3] = 255;
+    }
   }
   ctx.putImageData(img, 0, 0);
   const png = await canvas.encode("png");

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -18,6 +18,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   if (body.width != null) update.width = Number(body.width);
   if (body.height != null) update.height = Number(body.height);
   if (body.rotation != null) update.rotation = Number(body.rotation);
+  if (body.bitDepth != null) update.bitDepth = Number(body.bitDepth) === 24 ? 24 : 1;
   if (body.layout != null) update.layout = body.layout;
   if (body.background != null) update.background = body.background === "black" ? "black" : "white";
 

--- a/app/api/devices/route.ts
+++ b/app/api/devices/route.ts
@@ -16,6 +16,7 @@ export async function POST(req: NextRequest) {
   const width = Number(body.width ?? 800);
   const height = Number(body.height ?? 480);
   const rotation = Number(body.rotation ?? 0) as 0 | 90 | 180 | 270;
+  const bitDepth = (Number(body.bitDepth) === 24 ? 24 : 1) as 1 | 24;
   if (!slug) return NextResponse.json({ error: "slug required" }, { status: 400 });
 
   const existing = await col.findOne({ slug });
@@ -23,7 +24,7 @@ export async function POST(req: NextRequest) {
 
   const now = new Date();
   const doc = {
-    slug, name, width, height, rotation,
+    slug, name, width, height, rotation, bitDepth,
     layout: body.layout ?? [],
     createdAt: now, updatedAt: now,
   };

--- a/app/devices/new/page.tsx
+++ b/app/devices/new/page.tsx
@@ -3,14 +3,14 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 const PRESETS = [
-  { name: "Waveshare 7.5\" (800×480)", width: 800, height: 480 },
-  { name: "Waveshare 4.2\" (400×300)", width: 400, height: 300 },
-  { name: "Waveshare 2.9\" (296×128)", width: 296, height: 128 },
-  { name: "Waveshare 2.13\" (250×122)", width: 250, height: 122 },
-  { name: "Waveshare 7.5\" HD (880×528)", width: 880, height: 528 },
-  { name: "Waveshare 10.3\" (1872×1404)", width: 1872, height: 1404 },
-  { name: "28\" 16-bit greyscale (3840×1080)", width: 3840, height: 1080 },
-  { name: "Custom", width: 0, height: 0 },
+  { name: "Waveshare 7.5\" (800×480)", width: 800, height: 480, bitDepth: 1 },
+  { name: "Waveshare 4.2\" (400×300)", width: 400, height: 300, bitDepth: 1 },
+  { name: "Waveshare 2.9\" (296×128)", width: 296, height: 128, bitDepth: 1 },
+  { name: "Waveshare 2.13\" (250×122)", width: 250, height: 122, bitDepth: 1 },
+  { name: "Waveshare 7.5\" HD (880×528)", width: 880, height: 528, bitDepth: 1 },
+  { name: "Waveshare 10.3\" (1872×1404)", width: 1872, height: 1404, bitDepth: 1 },
+  { name: "28\" greyscale 24-bpp (3840×1080)", width: 3840, height: 1080, bitDepth: 24 },
+  { name: "Custom", width: 0, height: 0, bitDepth: 1 },
 ];
 
 export default function NewDevicePage() {
@@ -21,6 +21,7 @@ export default function NewDevicePage() {
   const [width, setWidth] = useState(800);
   const [height, setHeight] = useState(480);
   const [rotation, setRotation] = useState(0);
+  const [bitDepth, setBitDepth] = useState<1 | 24>(1);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -29,6 +30,7 @@ export default function NewDevicePage() {
     const p = PRESETS[i];
     if (p.width) setWidth(p.width);
     if (p.height) setHeight(p.height);
+    setBitDepth(p.bitDepth === 24 ? 24 : 1);
   };
 
   async function submit(e: React.FormEvent) {
@@ -38,7 +40,7 @@ export default function NewDevicePage() {
     const res = await fetch("/api/devices", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name, slug, width, height, rotation }),
+      body: JSON.stringify({ name, slug, width, height, rotation, bitDepth }),
     });
     setBusy(false);
     if (!res.ok) {
@@ -86,6 +88,13 @@ export default function NewDevicePage() {
               <option value={270}>270°</option>
             </select>
           </div>
+        </div>
+        <div>
+          <label className="label">BMP output format</label>
+          <select className="input" value={bitDepth} onChange={(e) => setBitDepth(Number(e.target.value) === 24 ? 24 : 1)}>
+            <option value={1}>1-bit monochrome (Waveshare default)</option>
+            <option value={24}>24-bit BGR (large greyscale e-ink controllers)</option>
+          </select>
         </div>
 
         {err && <p className="text-sm text-red-400">{err}</p>}

--- a/components/DeviceEditor.tsx
+++ b/components/DeviceEditor.tsx
@@ -18,6 +18,7 @@ export default function DeviceEditor({ device, assets }: Props) {
   const [width, setWidth] = useState(device.width);
   const [height, setHeight] = useState(device.height);
   const [rotation, setRotation] = useState(device.rotation ?? 0);
+  const [bitDepth, setBitDepth] = useState<1 | 24>(device.bitDepth === 24 ? 24 : 1);
   const [layout, setLayout] = useState<Block[]>(device.layout ?? []);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState<null | Date>(null);
@@ -32,7 +33,7 @@ export default function DeviceEditor({ device, assets }: Props) {
     const res = await fetch(`/api/devices/${device._id}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name, slug, width, height, rotation, layout }),
+      body: JSON.stringify({ name, slug, width, height, rotation, bitDepth, layout }),
     });
     setSaving(false);
     if (!res.ok) {
@@ -68,7 +69,7 @@ export default function DeviceEditor({ device, assets }: Props) {
       {err && <div className="card border-red-700 text-red-300">{err}</div>}
       {saved && <div className="text-xs text-emerald-400">Saved {saved.toLocaleTimeString()}.</div>}
 
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-5 gap-3">
         <div><label className="label">Name</label><input className="input" value={name} onChange={(e) => setName(e.target.value)} /></div>
         <div><label className="label">Slug</label><input className="input" value={slug} onChange={(e) => setSlug(e.target.value)} /></div>
         <div><label className="label">Width × Height</label>
@@ -83,6 +84,12 @@ export default function DeviceEditor({ device, assets }: Props) {
             <option value={90}>90°</option>
             <option value={180}>180°</option>
             <option value={270}>270°</option>
+          </select>
+        </div>
+        <div><label className="label">BMP format</label>
+          <select className="input" value={bitDepth} onChange={(e) => setBitDepth(Number(e.target.value) === 24 ? 24 : 1)}>
+            <option value={1}>1-bit mono</option>
+            <option value={24}>24-bit BGR</option>
           </select>
         </div>
       </div>

--- a/lib/bmp.ts
+++ b/lib/bmp.ts
@@ -60,6 +60,93 @@ export function encodeBmp1bit(width: number, height: number, pixels: Uint8Array)
   return buf;
 }
 
+// 24-bit BGR BMP encoder.
+// Input: width, height, and an RGBA buffer (4 bytes/pixel) matching canvas output.
+// Some e-ink controllers (e.g. the 28" 3840×1080 panel) refuse 1-bpp BMPs and
+// expect a 24-bpp Windows V3 BMP even when the source is monochrome — they read
+// the BGR channels and threshold internally.
+export function encodeBmp24bit(width: number, height: number, rgba: Uint8Array | Uint8ClampedArray): Buffer {
+  if (rgba.length !== width * height * 4) {
+    throw new Error(`rgba buffer length ${rgba.length} != ${width}*${height}*4`);
+  }
+
+  const rowBytes = width * 3;
+  const rowStride = (rowBytes + 3) & ~3;
+  const imageSize = rowStride * height;
+
+  const fileHeaderSize = 14;
+  const dibHeaderSize = 40;
+  const pixelOffset = fileHeaderSize + dibHeaderSize;
+  const fileSize = pixelOffset + imageSize;
+
+  const buf = Buffer.alloc(fileSize);
+
+  buf.write("BM", 0, "ascii");
+  buf.writeUInt32LE(fileSize, 2);
+  buf.writeUInt32LE(0, 6);
+  buf.writeUInt32LE(pixelOffset, 10);
+
+  buf.writeUInt32LE(dibHeaderSize, 14);
+  buf.writeInt32LE(width, 18);
+  buf.writeInt32LE(height, 22); // positive = bottom-up
+  buf.writeUInt16LE(1, 26);     // planes
+  buf.writeUInt16LE(24, 28);    // bits per pixel
+  buf.writeUInt32LE(0, 30);     // compression = BI_RGB
+  buf.writeUInt32LE(imageSize, 34);
+  buf.writeInt32LE(3779, 38);   // x pixels/meter (~96dpi to match sample)
+  buf.writeInt32LE(3779, 42);
+  buf.writeUInt32LE(0, 46);     // colors used
+  buf.writeUInt32LE(0, 50);     // important colors
+
+  // Pixel data — bottom-up, BGR
+  for (let y = 0; y < height; y++) {
+    const srcRow = (height - 1 - y) * width * 4;
+    const dstRow = pixelOffset + y * rowStride;
+    for (let x = 0; x < width; x++) {
+      const s = srcRow + x * 4;
+      const d = dstRow + x * 3;
+      // Treat transparent pixels as white.
+      if (rgba[s + 3] === 0) {
+        buf[d] = 255; buf[d + 1] = 255; buf[d + 2] = 255;
+      } else {
+        buf[d]     = rgba[s + 2]; // B
+        buf[d + 1] = rgba[s + 1]; // G
+        buf[d + 2] = rgba[s];     // R
+      }
+    }
+  }
+  return buf;
+}
+
+// Rotate an RGBA buffer (4 bytes/pixel) by 90/180/270 degrees. Returns
+// new buffer + dims. deg=0 returns the input unchanged.
+export function rotateRgba(rgba: Uint8ClampedArray, w: number, h: number, deg: number): { rgba: Uint8ClampedArray; width: number; height: number } {
+  if (!deg || deg % 360 === 0) return { rgba, width: w, height: h };
+  if (deg === 180) {
+    const out = new Uint8ClampedArray(rgba.length);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const src = (y * w + x) * 4;
+        const dst = ((h - 1 - y) * w + (w - 1 - x)) * 4;
+        out[dst] = rgba[src]; out[dst + 1] = rgba[src + 1]; out[dst + 2] = rgba[src + 2]; out[dst + 3] = rgba[src + 3];
+      }
+    }
+    return { rgba: out, width: w, height: h };
+  }
+  const nw = h, nh = w;
+  const out = new Uint8ClampedArray(rgba.length);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const src = (y * w + x) * 4;
+      const dst = deg === 90
+        ? (x * nw + (h - 1 - y)) * 4
+        : ((w - 1 - x) * nw + y) * 4;
+      out[dst] = rgba[src]; out[dst + 1] = rgba[src + 1]; out[dst + 2] = rgba[src + 2]; out[dst + 3] = rgba[src + 3];
+    }
+  }
+  return { rgba: out, width: nw, height: nh };
+}
+
 // Convert RGBA canvas pixels to a 1-bit buffer (1 = white).
 // mode: "threshold" does flat cutoff; "dither" does Floyd–Steinberg.
 export function rgbaTo1Bit(

--- a/lib/mongo.ts
+++ b/lib/mongo.ts
@@ -119,6 +119,10 @@ export type DeviceDoc = {
   height: number;
   rotation?: 0 | 90 | 180 | 270;
   background?: "white" | "black";
+  // Output BMP bit depth. 1 = monochrome (default, works on most Waveshare
+  // panels). 24 = 24-bit BGR BMP for controllers that refuse 1-bpp input
+  // (e.g. the 28" 3840×1080 panel).
+  bitDepth?: 1 | 24;
   layout: Block[];
   updatedAt: Date;
   createdAt: Date;

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -2,7 +2,7 @@ import { createCanvas, loadImage, SKRSContext2D } from "@napi-rs/canvas";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { AssetDoc, Block, DeviceDoc } from "./mongo";
-import { encodeBmp1bit, rgbaTo1Bit } from "./bmp";
+import { encodeBmp1bit, encodeBmp24bit, rgbaTo1Bit, rotateRgba } from "./bmp";
 import { ensureFontsRegistered, fontString } from "./fonts";
 import { renderQr } from "./qr";
 import { abbreviateDay, dayOfMonth, formatTimeParts, monthName, parseFlexible } from "./dates";
@@ -53,15 +53,20 @@ export async function renderDevice(
   let outW = editW;
   let outH = editH;
   let outPixels = pixels1;
+  let outRgba: Uint8ClampedArray = rgba;
   if (device.rotation) {
     const r = rotatePixels(pixels1, editW, editH, device.rotation);
     outPixels = r.pixels;
     outW = r.width;
     outH = r.height;
+    const rr = rotateRgba(rgba, editW, editH, device.rotation);
+    outRgba = rr.rgba;
   }
 
-  const bmp = encodeBmp1bit(outW, outH, outPixels);
-  return { pixels1: outPixels, rgba, width: outW, height: outH, bmp };
+  const bmp = device.bitDepth === 24
+    ? encodeBmp24bit(outW, outH, outRgba)
+    : encodeBmp1bit(outW, outH, outPixels);
+  return { pixels1: outPixels, rgba: outRgba, width: outW, height: outH, bmp };
 }
 
 


### PR DESCRIPTION
## Summary

The 28" 3840×1080 e-ink panel won't render the existing 1-bpp BMP output — it requires a Windows V3 24-bpp BGR BMP and thresholds internally (per the `exiftool` dump of a working reference image: `Bit Depth: 24`, `Compression: None`, `Pixels Per Meter X/Y: 3779`).

This PR adds a per-device `bitDepth` setting and a 24-bit BMP path through the renderer:

- New `encodeBmp24bit()` in [lib/bmp.ts](lib/bmp.ts) that mirrors the reference format exactly (Windows V3 header, BI_RGB, 3779 ppm).
- New `rotateRgba()` so rotated devices can rotate the full-colour buffer without going through the 1-bit threshold step.
- `DeviceDoc.bitDepth?: 1 | 24` in [lib/mongo.ts](lib/mongo.ts).
- When `bitDepth === 24` the renderer skips threshold/dither and emits BGR straight from the canvas, so the panel gets the full anti-aliased greyscale. Preview PNGs are sourced from the RGBA buffer in this mode so the in-browser preview matches what the device receives.
- New-device form and device editor both expose a "BMP output format" select. The 28" preset auto-selects 24-bit.

## Why

The 28" sign was rendering as a "weird tiling thing" because its controller couldn't decode our 1-bpp BMP. Matching the working reference's bit depth fixes that without affecting any other device.

## Reviewer notes

- Existing 1-bit Waveshare devices are unaffected: `bitDepth` defaults to undefined, which falls into the `!== 24` (1-bit) branch everywhere.
- Verified the encoder output with `exiftool`: `BMP Version: Windows V3, Bit Depth: 24, Compression: None, Pixels Per Meter X/Y: 3779` — same as the user-supplied working sample.
- For existing 28" devices created before this change, switch the device editor's "BMP format" to 24-bit (or re-create from the preset).

## Test plan

- [ ] Create a new device with the "28\" greyscale 24-bpp" preset; confirm `bitDepth=24` is sent in the POST body.
- [ ] Fetch `/{slug}/current.bmp` and run `exiftool` — `Bit Depth: 24`, `BMP Version: Windows V3`.
- [ ] Load the 28" sign on the actual hardware and confirm the image renders correctly (no tiling artefact).
- [ ] Sanity-check an existing 1-bit Waveshare device: BMP output is unchanged (still 1-bpp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)