### PR TITLE
Make image upload obvious: styled button + auto-open file picker

### DIFF
--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -23,6 +23,10 @@ export default function ImageProcessor({ targetW, targetH, onConfirm, onCancel }
   const [drag, setDrag] = useState<{ startX: number; startY: number } | null>(null);
 
   useEffect(() => { redraw(); }, [img, crop, threshold, dither, invert, useNative, faithful]);
+  // Open the file picker as soon as the dialog mounts so "Upload image" feels
+  // like a single-click action instead of a "click, then hunt for the tiny
+  // input" two-step.
+  useEffect(() => { fileRef.current?.click(); }, []);
 
   function onFile(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -127,7 +131,10 @@ export default function ImageProcessor({ targetW, targetH, onConfirm, onCancel }
 
   return (
     <div className="space-y-3">
-      <input ref={fileRef} type="file" accept="image/*" onChange={onFile} className="text-sm" />
+      <input ref={fileRef} type="file" accept="image/*" onChange={onFile} className="hidden" />
+      <button type="button" className="btn w-full" onClick={() => fileRef.current?.click()}>
+        {img ? "Choose a different image…" : "Choose image file…"}
+      </button>
       <div className="flex items-center justify-between gap-3">
         <p className="text-xs text-neutral-400 flex-1">
           Drag on the source image to reselect a crop.{" "}


### PR DESCRIPTION
## Summary

Reported that "the upload image button does not do anything." The most likely cause is the bare native `<input type="file">` inside the ImageProcessor — in the 360px sidebar it's tiny and easy to mistake for nothing happening. The "Upload image" inspector button did open the ImageProcessor card, but the user then had to find the small file input inside it.

This PR makes the upload flow a single-click action:

- Hide the bare file input and expose a full-width styled button: **"Choose image file…"** (or "Choose a different image…" if one is already loaded). Clicking it triggers the hidden input.
- Auto-call `fileRef.current?.click()` on mount so opening the ImageProcessor immediately prompts the OS file picker.

## Reviewer notes

- The auto-open relies on the ImageProcessor mount being a direct consequence of a user click (the inspector's "Upload image" button → `setShowImage(true)`). Browsers generally allow programmatic file-input clicks that originate from a user-gesture call stack; if it's blocked, the user can still click the styled button to open the picker.

## Test plan

- [ ] Click "+ Image" in the toolbar — file picker opens immediately.
- [ ] Cancel the picker, then click "Choose image file…" — picker re-opens.
- [ ] After loading an image and clicking "Use this image", click "Replace image" on the block — picker re-opens.
- [ ] On a narrow sidebar, the styled button is still obviously clickable (full-width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)