### PR TITLE
Image upload: full-image default and always-locked aspect

### DIFF
--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -35,15 +35,38 @@ export default function ImageProcessor({ targetW, targetH, onConfirm, onCancel }
     const i = new Image();
     i.onload = () => {
       setImg(i);
-      // Default crop matches target aspect, centered
-      const aspect = targetW / targetH;
-      let cw = i.width, ch = i.height;
-      if (cw / ch > aspect) cw = Math.floor(ch * aspect);
-      else ch = Math.floor(cw / aspect);
-      setCrop({ x: Math.floor((i.width - cw) / 2), y: Math.floor((i.height - ch) / 2), w: cw, h: ch });
+      if (useNative) {
+        // Native mode: take the whole image, no crop required.
+        setCrop({ x: 0, y: 0, w: i.width, h: i.height });
+      } else {
+        // Default crop matches target aspect, centered.
+        const aspect = targetW / targetH;
+        let cw = i.width, ch = i.height;
+        if (cw / ch > aspect) cw = Math.floor(ch * aspect);
+        else ch = Math.floor(cw / aspect);
+        setCrop({ x: Math.floor((i.width - cw) / 2), y: Math.floor((i.height - ch) / 2), w: cw, h: ch });
+      }
     };
     i.src = url;
   }
+
+  // When the user toggles "Use native image size" on after the image has
+  // already loaded, expand the crop to the full image. Toggling off goes
+  // back to the target-aspect centered default so the two modes always
+  // produce a sane initial state.
+  useEffect(() => {
+    if (!img) return;
+    if (useNative) {
+      setCrop({ x: 0, y: 0, w: img.width, h: img.height });
+    } else {
+      const aspect = targetW / targetH;
+      let cw = img.width, ch = img.height;
+      if (cw / ch > aspect) cw = Math.floor(ch * aspect);
+      else ch = Math.floor(cw / aspect);
+      setCrop({ x: Math.floor((img.width - cw) / 2), y: Math.floor((img.height - ch) / 2), w: cw, h: ch });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useNative]);
 
   function startDrag(e: React.MouseEvent<HTMLCanvasElement>) {
     if (!img) return;

--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -166,17 +166,10 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
               targetW={selectedBlock.w}
               targetH={selectedBlock.h}
               onConfirm={(url, w, h) => {
-                // If the user opted into native size, the returned dims differ
-                // from the block's current w/h — snap the block to the image's
-                // native dimensions and lock the aspect so subsequent scaling
-                // stays proportional. Otherwise leave the block size alone.
-                const patch: Partial<Block> = { imageData: url };
-                if (w !== selectedBlock.w || h !== selectedBlock.h) {
-                  patch.w = w;
-                  patch.h = h;
-                  patch.lockAspect = true;
-                }
-                update(selectedBlock.id, patch);
+                // Snap the block to the output dimensions and lock the
+                // aspect so future scaling stays proportional — the user
+                // expects "upload image" to never stretch.
+                update(selectedBlock.id, { imageData: url, w, h, lockAspect: true });
                 setShowImage(false);
               }}
               onCancel={() => setShowImage(false)}


### PR DESCRIPTION
## Summary

Follow-up to the native-size upload flow. Two UX fixes:

1. **Default native-mode crop to the full image.** When "Use native image size" is on at upload time, the crop defaults to `(0, 0, img.width, img.height)` — no need to drag a rectangle. Toggling the checkbox after the image is loaded also resnaps the crop: on → full image, off → target-aspect centred. Each mode has a sane starting state.
2. **Always lock aspect on upload.** Every confirmed image now sets the block's `w`/`h` to the output dimensions and turns on `lockAspect`. Previously this only happened when output dims differed from the current block size, which meant a freshly created image block at the same default size as the upload would silently stay unlocked. With this change, scaling the block via the resize handle or W/H fields can never stretch the image.

## Test plan

- [ ] Click "+ Image", check "Use native image size", pick a file — preview shows the full image immediately, no manual crop needed.
- [ ] With an image already loaded, toggle the checkbox: on → full image, off → centred target-aspect crop.
- [ ] After confirming, the block on the canvas matches the image's native pixel dims and the resize handle preserves the aspect.
- [ ] Standard (non-native) upload still target-aspect-locks the crop and is delivered at the block's target W/H.

🤖 Generated with [Claude Code](https://claude.com/claude-code)