### PR TITLE
Allow line blocks to pick white or black explicitly

### DIFF
--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -294,7 +294,7 @@ function BlockView({
           <span>📅 {block.dateISO?.slice(0, 10) || "date"}</span>
         </div>
       ) : block.type === "line" ? (
-        <div className={`bg-black ${block.lineDirection === "vertical" ? "w-[2px] h-full mx-auto" : "h-[2px] w-full my-auto"}`} />
+        <div className={`${block.lineColor === "white" ? "bg-white border border-neutral-400" : "bg-black"} ${block.lineDirection === "vertical" ? "w-[2px] h-full mx-auto" : "h-[2px] w-full my-auto"}`} />
       ) : block.type === "shape" ? (
         <div className={`w-full h-full ${block.shapeKind === "filled" ? "bg-black" : "border-2 border-black"}`} />
       ) : (
@@ -590,7 +590,7 @@ function DateFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<B
 
 function LineFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<Block>) => void }) {
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-3 gap-2">
       <div>
         <label className="label">Direction</label>
         <select className="input" value={block.lineDirection ?? "horizontal"} onChange={(e) => onUpdate({ lineDirection: e.target.value as any })}>
@@ -601,6 +601,14 @@ function LineFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<B
       <div>
         <label className="label">Thickness (px)</label>
         <input type="number" className="input" value={block.lineThickness ?? 1} onChange={(e) => onUpdate({ lineThickness: Number(e.target.value) })} />
+      </div>
+      <div>
+        <label className="label">Color</label>
+        <select className="input" value={block.lineColor ?? "auto"} onChange={(e) => onUpdate({ lineColor: e.target.value === "auto" ? undefined : (e.target.value as "white" | "black") })}>
+          <option value="auto">Auto (contrast bg)</option>
+          <option value="black">Black</option>
+          <option value="white">White</option>
+        </select>
       </div>
     </div>
   );

--- a/lib/mongo.ts
+++ b/lib/mongo.ts
@@ -102,6 +102,9 @@ export type Block = {
   // line
   lineDirection?: "horizontal" | "vertical";
   lineThickness?: number;
+  // Explicit colour for line blocks. Falls back to the contrast colour of
+  // the surrounding background when unset.
+  lineColor?: "white" | "black";
 
   // shape
   shapeKind?: "filled" | "outlined";

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -372,7 +372,9 @@ function drawDate(ctx: SKRSContext2D, block: Block, fg: string, dctx: DrawCtx) {
 
 function drawLine(ctx: SKRSContext2D, block: Block, fg: string) {
   const t = Math.max(1, block.lineThickness ?? 1);
-  ctx.fillStyle = fg;
+  ctx.fillStyle = block.lineColor === "white" ? "#ffffff"
+                : block.lineColor === "black" ? "#000000"
+                : fg;
   if (block.lineDirection === "vertical") {
     ctx.fillRect(block.x + Math.floor((block.w - t) / 2), block.y, t, block.h);
   } else {


### PR DESCRIPTION
## Summary

Line blocks previously always rendered in the contrast colour of the surrounding background (white on black, black on white). That made it impossible to draw, say, an inverted accent line on a black device. This PR adds an explicit `lineColor` per line block with three options: **Auto (contrast bg)**, **Black**, **White**.

- New optional `Block.lineColor?: "white" | "black"`. Unset preserves the existing auto-contrast behaviour, so existing lines render exactly the same.
- `drawLine()` honours `lineColor` when set, falls through to `fg` otherwise.
- The line-block inspector grows a Color select (Auto/Black/White).
- The in-editor preview reflects the choice — white lines get a thin neutral outline so they stay visible on the white editor canvas.

## Test plan

- [ ] Add a horizontal line on a black-background device — defaults render white (auto contrast). Set Color: Black — line goes black; the rendered preview matches.
- [ ] Add a vertical line on a white device — defaults render black. Set Color: White — line goes white with the editor outline visible.
- [ ] Old saved devices with lines render unchanged (no `lineColor` field stored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)