### PR TITLE
Fix smeared QR rendering and add horizontal-bars style

### DIFF
--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -505,6 +505,7 @@ function TextFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<B
 }
 
 function QrFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<Block>) => void }) {
+  const style = block.qrStyle ?? "square";
   return (
     <div className="space-y-2">
       <div>
@@ -525,8 +526,21 @@ function QrFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<Blo
             <option value="H">High (30%)</option>
           </select>
         </div>
+        <div>
+          <label className="label">Style</label>
+          <select className="input" value={style} onChange={(e) => onUpdate({ qrStyle: e.target.value as "square" | "bars" })}>
+            <option value="square">Square (classic)</option>
+            <option value="bars">Horizontal bars</option>
+          </select>
+        </div>
+        {style === "bars" && (
+          <div>
+            <label className="label">Vertical shrink ({(block.qrVerticalShrink ?? 0.8).toFixed(2)})</label>
+            <input type="range" min={0.2} max={1} step={0.05} value={block.qrVerticalShrink ?? 0.8} onChange={(e) => onUpdate({ qrVerticalShrink: Number(e.target.value) })} className="w-full" />
+          </div>
+        )}
       </div>
-      <p className="text-xs text-neutral-500">Right-aligned inside the block, integer nearest-neighbor scale. Use a square block for best results.</p>
+      <p className="text-xs text-neutral-500">Right-aligned inside the block, integer module size for crispness. Bars style merges horizontally-adjacent modules — keep error correction ≥ M for reliable scanning.</p>
     </div>
   );
 }

--- a/lib/mongo.ts
+++ b/lib/mongo.ts
@@ -88,6 +88,13 @@ export type Block = {
   qrUrl?: string;
   qrMargin?: number;         // pixels of quiet zone outside the QR within the block
   qrErrorLevel?: "L" | "M" | "Q" | "H";
+  // Module style. "square" = classic filled squares per module (default).
+  // "bars" = horizontal-bar style modelled on python-qrcode's
+  // HorizontalSquareBarsDrawer: each active module is drawn as a
+  // full-width, vertically-shrunken bar so consecutive active modules in
+  // a row visually merge into a single band.
+  qrStyle?: "square" | "bars";
+  qrVerticalShrink?: number; // 0..1, only for "bars" style; default 0.8
 
   // date
   dateISO?: string;          // e.g. "2026-05-01" or full ISO

--- a/lib/qr.ts
+++ b/lib/qr.ts
@@ -1,50 +1,50 @@
 import QRCode from "qrcode";
-import { createCanvas, SKRSContext2D } from "@napi-rs/canvas";
+import { SKRSContext2D } from "@napi-rs/canvas";
 
-// Legacy behaviour: border=0 ("no quiet zone baked in"), nearest-neighbor
-// scale to fill the target. We produce a 1-bit module grid then blit it
-// with nearest-neighbor so the QR stays crisp on e-ink.
+// We paint modules directly as filled rectangles at the target scale —
+// no offscreen 1-module-per-pixel canvas + upscale, which used to leave
+// modules looking smeared/striped after the 1-bit threshold pass.
 //
-// Returns a canvas the caller can drawImage into target block.
+// Two styles:
+//   "square" — classic: every active module is a `modulePx × modulePx`
+//              solid square.
+//   "bars"   — port of python-qrcode's HorizontalSquareBarsDrawer:
+//              each active module is a full-width × shrunken-height
+//              bar, vertically centred. Consecutive active modules in a
+//              row merge into a continuous band; rows are separated by
+//              a vertical gap of `(1 - verticalShrink) * modulePx`.
+
+export type QrStyle = "square" | "bars";
 
 export async function renderQr(
   ctx: SKRSContext2D,
   text: string,
   rect: { x: number; y: number; w: number; h: number },
-  opts: { margin?: number; errorLevel?: "L" | "M" | "Q" | "H" } = {}
+  opts: {
+    margin?: number;
+    errorLevel?: "L" | "M" | "Q" | "H";
+    style?: QrStyle;
+    verticalShrink?: number; // bars only; clamped to [0.1, 1]
+  } = {}
 ) {
   if (!text) return;
 
   const errorLevel = opts.errorLevel ?? "L";
   const margin = Math.max(0, opts.margin ?? 0);
-  // Produce the module grid.
+  const style: QrStyle = opts.style ?? "square";
+  const verticalShrink = Math.min(1, Math.max(0.1, opts.verticalShrink ?? 0.8));
+
   const qr = QRCode.create(text, { errorCorrectionLevel: errorLevel });
   const size = qr.modules.size;
   const data = qr.modules.data as Uint8Array | number[];
 
-  // Draw base at 1 module/px to an offscreen, then nearest-neighbor scale
-  // into the target rect.
-  const off = createCanvas(size, size);
-  const octx = off.getContext("2d");
-  // @ts-ignore
-  octx.imageSmoothingEnabled = false;
-  const img = octx.createImageData(size, size);
-  for (let i = 0; i < size * size; i++) {
-    const v = data[i] ? 0 : 255; // 1 = dark module
-    const p = i * 4;
-    img.data[p] = v; img.data[p + 1] = v; img.data[p + 2] = v; img.data[p + 3] = 255;
-  }
-  octx.putImageData(img, 0, 0);
-
-  // Figure out the side length: square, min of (w, h), minus margin*2, then
-  // rounded down to a multiple of the module count so every module is an
-  // equal integer number of output pixels (perfectly crisp).
+  // Round the module size down so every module is an equal integer number
+  // of output pixels — that's what keeps the result crisp after the 1-bit
+  // threshold downstream.
   const maxSide = Math.max(1, Math.min(rect.w, rect.h) - margin * 2);
   const modulePx = Math.max(1, Math.floor(maxSide / size));
   const side = modulePx * size;
 
-  // Right-align + vertically center — this matches the legacy layout where
-  // the QR sits on the right edge of the event box.
   const dx = rect.x + rect.w - side - margin;
   const dy = rect.y + Math.floor((rect.h - side) / 2);
 
@@ -52,7 +52,45 @@ export async function renderQr(
   ctx.fillStyle = "#ffffff";
   ctx.fillRect(dx - margin, dy - margin, side + margin * 2, side + margin * 2);
 
-  // @ts-ignore
-  ctx.imageSmoothingEnabled = false;
-  ctx.drawImage(off, dx, dy, side, side);
+  ctx.fillStyle = "#000000";
+  if (style === "bars") {
+    const barH = Math.max(1, Math.round(modulePx * verticalShrink));
+    const barOffset = Math.floor((modulePx - barH) / 2);
+    for (let y = 0; y < size; y++) {
+      // Coalesce horizontally-adjacent active modules into a single fillRect.
+      let runStart = -1;
+      for (let x = 0; x <= size; x++) {
+        const active = x < size && !!data[y * size + x];
+        if (active && runStart < 0) runStart = x;
+        if (!active && runStart >= 0) {
+          ctx.fillRect(
+            dx + runStart * modulePx,
+            dy + y * modulePx + barOffset,
+            (x - runStart) * modulePx,
+            barH
+          );
+          runStart = -1;
+        }
+      }
+    }
+    return;
+  }
+
+  // "square" style — also coalesce horizontal runs so we issue fewer fills.
+  for (let y = 0; y < size; y++) {
+    let runStart = -1;
+    for (let x = 0; x <= size; x++) {
+      const active = x < size && !!data[y * size + x];
+      if (active && runStart < 0) runStart = x;
+      if (!active && runStart >= 0) {
+        ctx.fillRect(
+          dx + runStart * modulePx,
+          dy + y * modulePx,
+          (x - runStart) * modulePx,
+          modulePx
+        );
+        runStart = -1;
+      }
+    }
+  }
 }

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -279,6 +279,8 @@ async function drawQrBlock(ctx: SKRSContext2D, block: Block, dctx: DrawCtx, fg: 
   await renderQr(ctx, url, { x: block.x, y: block.y, w: block.w, h: block.h }, {
     margin: block.qrMargin ?? 0,
     errorLevel: block.qrErrorLevel ?? "L",
+    style: block.qrStyle ?? "square",
+    verticalShrink: block.qrVerticalShrink ?? 0.8,
   });
 }
 


### PR DESCRIPTION
## Summary

Two QR changes:

### 1. Fix the smeared/striped QR output

The previous renderer built a `size × size` offscreen image (1 pixel per module) and then `drawImage`-scaled it up to the target. On `@napi-rs/canvas` the `imageSmoothingEnabled = false` hint isn't always honoured, so the upscale was being filtered — once the result hit the 1-bit threshold downstream, the smeared edges turned into the speckled/striped output users were seeing.

Now we paint modules directly as filled rectangles at the target scale, no offscreen + upscale. Horizontally-adjacent active modules are coalesced into a single `fillRect` per run, so paint cost stays low even for big QRs.

### 2. New "Horizontal bars" QR style

Port of python-qrcode's `HorizontalSquareBarsDrawer`. Each active module renders as a full-width × shrunken-height bar, vertically centred — consecutive active modules in a row merge into a continuous band, with a vertical gap between rows proportional to `(1 - verticalShrink)`. (The Python drawer's rounded-end branch is dead code — both halves use `SQUARE` — so this port intentionally skips rounding.)

- New optional `Block.qrStyle?: "square" | "bars"` and `Block.qrVerticalShrink?: number` (0.1–1, default 0.8).
- `QrFields` inspector gets a Style select; bars mode reveals a Vertical-shrink slider.
- Helper text recommends error correction ≥ M for bars, since bars obliterate vertical edges within modules.

## Reviewer notes

- Existing QR blocks (no `qrStyle` set) render in the classic square style, which is now also crisper because of the direct-paint fix.
- The `qr` import is unchanged — still `qrcode`'s `QRCode.create()` for the module grid.

## Test plan

- [ ] Render an existing QR block — output is crisp, no striping (compare to the user-supplied "weird" sample).
- [ ] Switch a QR to "Horizontal bars" — preview shows horizontal banding with vertical gaps.
- [ ] Drag the Vertical-shrink slider — bars get thicker / thinner.
- [ ] Confirm a phone can still scan a bars-style QR at error correction M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)