### PR TITLE
QR: default to inverted; fix bars-style finder patterns

### DIFF
--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -540,7 +540,11 @@ function QrFields({ block, onUpdate }: { block: Block; onUpdate: (p: Partial<Blo
           </div>
         )}
       </div>
-      <p className="text-xs text-neutral-500">Right-aligned inside the block, integer module size for crispness. Bars style merges horizontally-adjacent modules — keep error correction ≥ M for reliable scanning.</p>
+      <label className="text-sm flex items-center gap-1">
+        <input type="checkbox" checked={block.qrInvert ?? true} onChange={(e) => onUpdate({ qrInvert: e.target.checked })} />
+        Invert (black quiet zone, white modules)
+      </label>
+      <p className="text-xs text-neutral-500">Right-aligned inside the block, integer module size for crispness. Bars style keeps the three finder patterns solid; everywhere else, horizontally-adjacent active modules merge into a bar. Keep error correction ≥ M for reliable scanning.</p>
     </div>
   );
 }

--- a/lib/mongo.ts
+++ b/lib/mongo.ts
@@ -95,6 +95,10 @@ export type Block = {
   // a row visually merge into a single band.
   qrStyle?: "square" | "bars";
   qrVerticalShrink?: number; // 0..1, only for "bars" style; default 0.8
+  // When unset/true, the QR renders inverted: black quiet zone + white
+  // modules — looks correct against the default black device background
+  // and saves ink. Set explicitly to false for a classic white-bg QR.
+  qrInvert?: boolean;
 
   // date
   dateISO?: string;          // e.g. "2026-05-01" or full ISO

--- a/lib/qr.ts
+++ b/lib/qr.ts
@@ -25,6 +25,7 @@ export async function renderQr(
     errorLevel?: "L" | "M" | "Q" | "H";
     style?: QrStyle;
     verticalShrink?: number; // bars only; clamped to [0.1, 1]
+    invert?: boolean;        // default true: black quiet zone, white modules
   } = {}
 ) {
   if (!text) return;
@@ -33,6 +34,7 @@ export async function renderQr(
   const margin = Math.max(0, opts.margin ?? 0);
   const style: QrStyle = opts.style ?? "square";
   const verticalShrink = Math.min(1, Math.max(0.1, opts.verticalShrink ?? 0.8));
+  const invert = opts.invert ?? true;
 
   const qr = QRCode.create(text, { errorCorrectionLevel: errorLevel });
   const size = qr.modules.size;
@@ -48,29 +50,47 @@ export async function renderQr(
   const dx = rect.x + rect.w - side - margin;
   const dy = rect.y + Math.floor((rect.h - side) / 2);
 
-  // White quiet zone (background) behind QR so invert/overlays don't clobber it.
-  ctx.fillStyle = "#ffffff";
+  const bgColor = invert ? "#000000" : "#ffffff";
+  const fgColor = invert ? "#ffffff" : "#000000";
+
+  // Quiet zone — matches the QR's own background colour so adjacent
+  // surroundings don't create false edges for scanners.
+  ctx.fillStyle = bgColor;
   ctx.fillRect(dx - margin, dy - margin, side + margin * 2, side + margin * 2);
 
-  ctx.fillStyle = "#000000";
+  ctx.fillStyle = fgColor;
+
+  // Finder patterns must stay solid: scanners locate them by the 1:1:3:1:1
+  // ratio across both axes, which the bars style would otherwise destroy.
+  // They occupy a 7×7 area at three corners.
+  const isFinder = (x: number, y: number) =>
+    (x < 7 && y < 7) ||
+    (x >= size - 7 && y < 7) ||
+    (x < 7 && y >= size - 7);
+
   if (style === "bars") {
     const barH = Math.max(1, Math.round(modulePx * verticalShrink));
     const barOffset = Math.floor((modulePx - barH) / 2);
     for (let y = 0; y < size; y++) {
-      // Coalesce horizontally-adjacent active modules into a single fillRect.
+      // Coalesce same-status (finder/non-finder) active runs and emit
+      // one fillRect per run — full square for finder runs, vertically
+      // shrunken bar for data runs.
       let runStart = -1;
+      let runFinder = false;
+      const flush = (endExcl: number) => {
+        if (runStart < 0) return;
+        if (runFinder) {
+          ctx.fillRect(dx + runStart * modulePx, dy + y * modulePx, (endExcl - runStart) * modulePx, modulePx);
+        } else {
+          ctx.fillRect(dx + runStart * modulePx, dy + y * modulePx + barOffset, (endExcl - runStart) * modulePx, barH);
+        }
+        runStart = -1;
+      };
       for (let x = 0; x <= size; x++) {
         const active = x < size && !!data[y * size + x];
-        if (active && runStart < 0) runStart = x;
-        if (!active && runStart >= 0) {
-          ctx.fillRect(
-            dx + runStart * modulePx,
-            dy + y * modulePx + barOffset,
-            (x - runStart) * modulePx,
-            barH
-          );
-          runStart = -1;
-        }
+        const fin = x < size && isFinder(x, y);
+        if (runStart >= 0 && (!active || fin !== runFinder)) flush(x);
+        if (active && runStart < 0) { runStart = x; runFinder = fin; }
       }
     }
     return;

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -269,18 +269,15 @@ function wrapText(ctx: SKRSContext2D, text: string, maxWidth: number): string[] 
 async function drawQrBlock(ctx: SKRSContext2D, block: Block, dctx: DrawCtx, fg: string) {
   const url = applyVars(block.qrUrl ?? block.text ?? "", dctx);
   if (!url) return;
-  // QR always needs white modules around it to scan — paint the block white
-  // first if our context is otherwise black.
-  const parentBg = dctx.defaultBg === "black" ? "black" : "white";
-  if (parentBg === "black") {
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(block.x, block.y, block.w, block.h);
-  }
+  // renderQr paints its own quiet zone in the chosen polarity, so we don't
+  // need to pre-fill the block — doing so would overwrite the inverted
+  // (black-bg) QR's intended quiet zone.
   await renderQr(ctx, url, { x: block.x, y: block.y, w: block.w, h: block.h }, {
     margin: block.qrMargin ?? 0,
     errorLevel: block.qrErrorLevel ?? "L",
     style: block.qrStyle ?? "square",
     verticalShrink: block.qrVerticalShrink ?? 0.8,
+    invert: block.qrInvert ?? true,
   });
 }
 


### PR DESCRIPTION
## Summary

Two QR fixes:

### 1. Default to inverted output (black quiet zone, white modules)

To match the new default-black device background and save ink, QR blocks now render inverted by default — the quiet zone is black, the modules are white. New `Block.qrInvert?: boolean` defaulting to `true` when unset; uncheck the new inspector toggle to revert to the classic white-bg / black-modules look.

Also removed the legacy "pre-paint the block white" step in `drawQrBlock` — that used to be there to guarantee a white quiet zone behind the QR on black device backgrounds, but with the new inverted default it was overwriting the QR's own black quiet zone.

### 2. Bars-style QR was unscannable — finder patterns now stay solid

The bars style applied the vertical shrink to **every** module, including the three 7×7 finder patterns at the corners. Scanners locate a QR by hunting for the finder pattern's **1:1:3:1:1 dark-light ratio along both axes** — once the vertical scan ratio collapsed into a striped "thin-gap-thin-gap-thin…" pattern, the scanner gave up.

Fix: in bars mode, detect the three finder regions and render them as **solid squares** (full module height). Only data modules become vertically-shrunken bars. Within a row, contiguous active modules of the same type (finder vs. data) still coalesce into a single `fillRect`, so paint cost stays low.

Inspector helper text now explains the finder-solid behaviour.

## Reviewer notes

- Existing QR blocks without `qrInvert` set will flip to inverted on next render. Set `qrInvert: false` (uncheck the new checkbox) to keep the old look.
- The finder-pattern preservation applies only to `qrStyle === "bars"`. Square mode is unchanged.
- Alignment patterns (in larger QRs) are not specially handled — they're smaller (5×5) and error correction can usually absorb the distortion. If a specific high-version QR fails to scan, we can extend the same approach to them.

## Test plan

- [ ] New QR block — preview shows black background with white modules. Phone scan succeeds.
- [ ] Uncheck "Invert" — preview flips back to classic white-bg / black-modules; scan still succeeds.
- [ ] Switch style to "Horizontal bars" — finder patterns are now obvious solid squares; data area is banded. Phone scan succeeds (use error correction M or higher).
- [ ] Increase vertical shrink slider — bars get thicker / thinner; finder squares stay the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)