### PR TITLE
Plugin architecture: SVG renderer, media library, draft/publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,12 @@ APP_PASSWORD=changeme
 
 # Session signing secret (random string)
 SESSION_SECRET=replace-with-random-string
+
+# Wildmile MongoDB — used by the plant-heatmap, trash-dashboard, events,
+# and any plugin with a `mongo-wildmile` data source. Use a read-only
+# credential; lib/plugins/wildmile.ts also enforces a collection allowlist.
+WILDMILE_MONGODB_URI=
+WILDMILE_MONGODB_DB=wildmile
+
+# Anthropic API key — only needed if you use the `claude-gen` plugin type.
+ANTHROPIC_API_KEY=

--- a/app/api/devices/[id]/publish/route.ts
+++ b/app/api/devices/[id]/publish/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ObjectId, devices } from "@/lib/mongo";
+
+// Copy draftLayout → layout. The public pull endpoint always serves the
+// live `layout` field, so until you publish, drafts are invisible to
+// devices in the field.
+export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  const col = await devices();
+  const doc = await col.findOne({ _id: new ObjectId(params.id) });
+  if (!doc) return NextResponse.json({ error: "not found" }, { status: 404 });
+  if (!doc.draftLayout || doc.draftLayout.length === 0) {
+    return NextResponse.json({ error: "no draft to publish" }, { status: 400 });
+  }
+  const now = new Date();
+  await col.updateOne(
+    { _id: doc._id },
+    { $set: { layout: doc.draftLayout, draftLayout: undefined, updatedAt: now } }
+  );
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -20,6 +20,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   if (body.rotation != null) update.rotation = Number(body.rotation);
   if (body.bitDepth != null) update.bitDepth = Number(body.bitDepth) === 24 ? 24 : 1;
   if (body.layout != null) update.layout = body.layout;
+  if (body.draftLayout !== undefined) update.draftLayout = body.draftLayout;
   if (body.background != null) update.background = body.background === "black" ? "black" : "white";
 
   const r = await col.findOneAndUpdate(

--- a/app/api/layouts/[id]/apply/route.ts
+++ b/app/api/layouts/[id]/apply/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ObjectId } from "mongodb";
+import { layouts, devices } from "@/lib/mongo";
+
+// POST /api/layouts/<id>/apply  body: { deviceId, target: "draft" | "live" }
+// Copies a template's blocks onto the device's draft (default) or live
+// layout. Default is draft so the user can review on /devices/<id> before
+// publishing to the field.
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad layout id" }, { status: 400 });
+  const body = await req.json();
+  const deviceId = String(body.deviceId ?? "");
+  if (!ObjectId.isValid(deviceId)) return NextResponse.json({ error: "bad deviceId" }, { status: 400 });
+  const target = body.target === "live" ? "live" : "draft";
+
+  const lcol = await layouts();
+  const lay = await lcol.findOne({ _id: new ObjectId(params.id) });
+  if (!lay) return NextResponse.json({ error: "layout not found" }, { status: 404 });
+
+  const dcol = await devices();
+  const update: Record<string, unknown> = { updatedAt: new Date() };
+  // Deep-clone block ids so duplicated blocks don't share keys with the
+  // template (matters for the editor's selection model).
+  const cloned = (lay.layout as any[]).map((b) => ({ ...b, id: Math.random().toString(36).slice(2, 10) }));
+  if (target === "live") update.layout = cloned;
+  else update.draftLayout = cloned;
+
+  const r = await dcol.findOneAndUpdate(
+    { _id: new ObjectId(deviceId) },
+    { $set: update },
+    { returnDocument: "after" }
+  );
+  if (!r) return NextResponse.json({ error: "device not found" }, { status: 404 });
+  return NextResponse.json({ ok: true, target, blocks: cloned.length });
+}

--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ObjectId } from "mongodb";
+import { layouts } from "@/lib/mongo";
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const col = await layouts();
+  const d = await col.findOne({ _id: new ObjectId(params.id) });
+  if (!d) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ...d, _id: String(d._id) });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const body = await req.json();
+  const col = await layouts();
+  const patch: Record<string, unknown> = { updatedAt: new Date() };
+  for (const k of ["name", "width", "height", "background", "layout"] as const) {
+    if (k in body) patch[k] = body[k];
+  }
+  const r = await col.findOneAndUpdate(
+    { _id: new ObjectId(params.id) },
+    { $set: patch },
+    { returnDocument: "after" }
+  );
+  if (!r) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ...r, _id: String(r._id) });
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const col = await layouts();
+  await col.deleteOne({ _id: new ObjectId(params.id) });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/layouts/route.ts
+++ b/app/api/layouts/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { layouts } from "@/lib/mongo";
+
+export async function GET() {
+  const col = await layouts();
+  const docs = await col.find({}).sort({ updatedAt: -1 }).toArray();
+  return NextResponse.json(docs.map((d) => ({ ...d, _id: String(d._id) })));
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const col = await layouts();
+  const now = new Date();
+  const doc = {
+    name: String(body.name ?? "Untitled layout"),
+    width: Number(body.width ?? 800),
+    height: Number(body.height ?? 480),
+    background: body.background === "white" ? "white" : "black",
+    layout: body.layout ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const r = await col.insertOne(doc as any);
+  return NextResponse.json({ ...doc, _id: String(r.insertedId) });
+}

--- a/app/api/media/[id]/route.ts
+++ b/app/api/media/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { deleteMedia, getMedia, dataUrlToBuffer } from "@/lib/media";
+
+// GET /api/media/<id>  → image bytes (use as <img src>)
+// GET /api/media/<id>?meta=1 → JSON record only
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const m = await getMedia(params.id);
+  if (!m) return new NextResponse("not found", { status: 404 });
+  const url = new URL(req.url);
+  if (url.searchParams.get("meta")) {
+    return NextResponse.json({ ...m, _id: String(m._id) });
+  }
+  if (!m.dataUrl) return new NextResponse("no bytes", { status: 404 });
+  const buf = dataUrlToBuffer(m.dataUrl);
+  // Wrap in a fresh Uint8Array so we satisfy NextResponse's BodyInit typing
+  // — TS doesn't yet model node Buffers as compatible.
+  return new NextResponse(new Uint8Array(buf), {
+    headers: { "content-type": m.mimeType, "cache-control": "no-store" },
+  });
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  await deleteMedia(params.id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listMedia, saveMedia } from "@/lib/media";
+
+export async function GET(req: NextRequest) {
+  const u = new URL(req.url);
+  const kind = u.searchParams.get("kind") as "upload" | "generated" | null;
+  const sourcePluginId = u.searchParams.get("sourcePluginId") ?? undefined;
+  const items = await listMedia({ kind: kind ?? undefined, sourcePluginId });
+  return NextResponse.json(items.map((m) => ({ ...m, _id: String(m._id) })));
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const dataUrl = String(body.dataUrl ?? "");
+  if (!dataUrl.startsWith("data:")) {
+    return NextResponse.json({ error: "dataUrl required" }, { status: 400 });
+  }
+  const mime = (dataUrl.match(/^data:([^;]+)/) ?? [])[1] ?? "application/octet-stream";
+  const saved = await saveMedia({
+    kind: "upload",
+    name: body.name ?? "Upload",
+    mimeType: mime,
+    width: Number(body.width ?? 0),
+    height: Number(body.height ?? 0),
+    dataUrl,
+  });
+  return NextResponse.json({ ...saved, _id: String(saved._id) });
+}

--- a/app/api/plugins/instances/[id]/preview.png/route.ts
+++ b/app/api/plugins/instances/[id]/preview.png/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ObjectId } from "mongodb";
+import { pluginInstances } from "@/lib/mongo";
+import { ensureFreshOutput } from "@/lib/plugins/runner";
+import { getMedia, dataUrlToBuffer } from "@/lib/media";
+
+// GET /api/plugins/instances/<id>/preview.png
+// Serves the latest generated PNG for an instance. The CMS instance page
+// hits this with a cache-buster query string after each refresh.
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return new NextResponse("bad id", { status: 400 });
+  await ensureFreshOutput(params.id);
+  const col = await pluginInstances();
+  const inst = await col.findOne({ _id: new ObjectId(params.id) });
+  if (!inst?.latestMediaId) return new NextResponse("no output yet", { status: 404 });
+  const m = await getMedia(inst.latestMediaId);
+  if (!m?.dataUrl) return new NextResponse("no media", { status: 404 });
+  const buf = dataUrlToBuffer(m.dataUrl);
+  return new NextResponse(new Uint8Array(buf), {
+    headers: {
+      "content-type": m.mimeType,
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/app/api/plugins/instances/[id]/refresh/route.ts
+++ b/app/api/plugins/instances/[id]/refresh/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+import { forceRefresh } from "@/lib/plugins/runner";
+
+export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  const inst = await forceRefresh(params.id);
+  if (!inst) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ...inst, _id: String(inst._id) });
+}

--- a/app/api/plugins/instances/[id]/route.ts
+++ b/app/api/plugins/instances/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ObjectId } from "mongodb";
+import { pluginInstances } from "@/lib/mongo";
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const col = await pluginInstances();
+  const d = await col.findOne({ _id: new ObjectId(params.id) });
+  if (!d) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ...d, _id: String(d._id) });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const body = await req.json();
+  const col = await pluginInstances();
+  const patch: Record<string, unknown> = { updatedAt: new Date() };
+  for (const k of ["name", "width", "height", "settings", "ttlSec"] as const) {
+    if (k in body) patch[k] = body[k];
+  }
+  // A settings change invalidates the cache — clear lastDataHash so the
+  // next pull regenerates even within TTL.
+  if ("settings" in body) patch.lastDataHash = null;
+  const r = await col.findOneAndUpdate(
+    { _id: new ObjectId(params.id) },
+    { $set: patch },
+    { returnDocument: "after" }
+  );
+  if (!r) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ...r, _id: String(r._id) });
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) return NextResponse.json({ error: "bad id" }, { status: 400 });
+  const col = await pluginInstances();
+  await col.deleteOne({ _id: new ObjectId(params.id) });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/plugins/instances/route.ts
+++ b/app/api/plugins/instances/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { pluginInstances } from "@/lib/mongo";
+import { getPluginType } from "@/lib/plugins/registry";
+
+export async function GET() {
+  const col = await pluginInstances();
+  const docs = await col.find({}).sort({ updatedAt: -1 }).toArray();
+  return NextResponse.json(docs.map(serialize));
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const typeId = String(body.typeId ?? "");
+  const type = getPluginType(typeId);
+  if (!type) return NextResponse.json({ error: `unknown plugin typeId ${typeId}` }, { status: 400 });
+
+  const col = await pluginInstances();
+  const now = new Date();
+  const doc = {
+    typeId,
+    name: String(body.name ?? `${type.name} instance`),
+    width: Number(body.width ?? type.defaultSize.w),
+    height: Number(body.height ?? type.defaultSize.h),
+    settings: body.settings ?? {},
+    ttlSec: Number(body.ttlSec ?? type.defaultTtlSec),
+    createdAt: now,
+    updatedAt: now,
+  };
+  const r = await col.insertOne(doc as any);
+  return NextResponse.json(serialize({ ...doc, _id: r.insertedId }));
+}
+
+function serialize(d: any) {
+  return { ...d, _id: String(d._id) };
+}

--- a/app/api/plugins/types/route.ts
+++ b/app/api/plugins/types/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { listPluginTypes, getPluginType } from "@/lib/plugins/registry";
+
+// GET /api/plugins/types  → registry metadata (id, name, defaultSize, etc.)
+// Used by the CMS to populate the "New plugin instance" picker.
+export async function GET() {
+  // Include a JSON-shaped settingsSchema description per type so the UI can
+  // generate a settings form without importing zod into the browser bundle.
+  const types = listPluginTypes().map((t) => {
+    const full = getPluginType(t.id)!;
+    return { ...t, settingsSchema: schemaShape(full.settingsSchema) };
+  });
+  return NextResponse.json(types);
+}
+
+// Minimal zod-schema introspection. We only need enough shape for the CMS
+// form to know which fields to render — full schema fidelity comes from
+// running validation server-side at runInstance() time.
+function schemaShape(schema: any): unknown {
+  try {
+    const def = schema._def;
+    if (!def) return { kind: "unknown" };
+    switch (def.typeName) {
+      case "ZodObject": {
+        const shape = def.shape();
+        const fields: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(shape)) {
+          fields[k] = schemaShape(v);
+        }
+        return { kind: "object", fields };
+      }
+      case "ZodString":
+        return { kind: "string" };
+      case "ZodNumber":
+        return { kind: "number" };
+      case "ZodBoolean":
+        return { kind: "boolean" };
+      case "ZodEnum":
+        return { kind: "enum", values: def.values };
+      case "ZodOptional":
+        return { kind: "optional", inner: schemaShape(def.innerType) };
+      case "ZodDefault":
+        return { kind: "default", inner: schemaShape(def.innerType), default: def.defaultValue() };
+      case "ZodArray":
+        return { kind: "array", element: schemaShape(def.type) };
+      case "ZodDiscriminatedUnion":
+        return { kind: "discriminatedUnion", discriminator: def.discriminator, options: def.options.map(schemaShape) };
+      case "ZodUnion":
+        return { kind: "union", options: def.options.map(schemaShape) };
+      case "ZodRecord":
+        return { kind: "record" };
+      case "ZodLiteral":
+        return { kind: "literal", value: def.value };
+      default:
+        return { kind: "unknown", typeName: def.typeName };
+    }
+  } catch {
+    return { kind: "unknown" };
+  }
+}

--- a/app/devices/[id]/page.tsx
+++ b/app/devices/[id]/page.tsx
@@ -1,19 +1,22 @@
 import { notFound } from "next/navigation";
-import { ObjectId, devices, assets as assetsColl } from "@/lib/mongo";
+import { ObjectId, devices, assets as assetsColl, pluginInstances } from "@/lib/mongo";
 import DeviceEditor from "@/components/DeviceEditor";
 
 export const dynamic = "force-dynamic";
 
 export default async function DevicePage({ params }: { params: { id: string } }) {
-  let device: any, assets: any[];
+  let device: any, assets: any[], plugins: any[];
   try {
     const col = await devices();
     device = await col.findOne({ _id: new ObjectId(params.id) });
     if (!device) notFound();
     const acol = await assetsColl();
     assets = (await acol.find({}).sort({ name: 1 }).toArray()).map((a) => ({ ...a, _id: String(a._id) }));
+    const pcol = await pluginInstances();
+    plugins = (await pcol.find({}, { projection: { name: 1, typeId: 1, width: 1, height: 1 } }).sort({ name: 1 }).toArray())
+      .map((p) => ({ ...p, _id: String(p._id) }));
   } catch (e: any) {
     return <div className="card border-red-700 text-red-300">DB error: {e.message}</div>;
   }
-  return <DeviceEditor device={{ ...device, _id: String(device._id) }} assets={assets} />;
+  return <DeviceEditor device={{ ...device, _id: String(device._id) }} assets={assets} plugins={plugins} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <nav className="flex items-center gap-4 text-sm">
                 <Link href="/" className="hover:text-emerald-400">Devices</Link>
                 <Link href="/assets" className="hover:text-emerald-400">Assets</Link>
+                <Link href="/plugins" className="hover:text-emerald-400">Plugins</Link>
+                <Link href="/media" className="hover:text-emerald-400">Media</Link>
+                <Link href="/layouts" className="hover:text-emerald-400">Layouts</Link>
                 <Link href="/devices/new" className="hover:text-emerald-400">+ New device</Link>
                 <form action="/api/auth/logout" method="post">
                   <button className="text-neutral-400 hover:text-red-400">Log out</button>

--- a/app/layouts/[id]/ApplyToDevice.tsx
+++ b/app/layouts/[id]/ApplyToDevice.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+type Device = { _id: string; name: string; slug: string; width: number; height: number };
+
+export default function ApplyToDevice({ layoutId, devices }: { layoutId: string; devices: Device[] }) {
+  const [deviceId, setDeviceId] = useState(devices[0]?._id ?? "");
+  const [target, setTarget] = useState<"draft" | "live">("draft");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  async function apply() {
+    if (!deviceId) return;
+    setBusy(true);
+    setMsg(null);
+    try {
+      const r = await fetch(`/api/layouts/${layoutId}/apply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ deviceId, target }),
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error ?? "apply failed");
+      setMsg(`Applied ${j.blocks} blocks to ${target}`);
+    } catch (e: any) {
+      setMsg(`Error: ${e.message}`);
+    }
+    setBusy(false);
+  }
+
+  if (devices.length === 0) {
+    return <div className="card text-neutral-400">Create a device first to apply a layout.</div>;
+  }
+
+  return (
+    <div className="card space-y-3 max-w-xl">
+      <div className="text-sm text-neutral-400">Apply this template to a device. Draft is invisible to the device until you click Publish.</div>
+      <label className="block">
+        <span className="text-sm text-neutral-400">Device</span>
+        <select className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                value={deviceId} onChange={(e) => setDeviceId(e.target.value)}>
+          {devices.map((d) => (
+            <option key={d._id} value={d._id}>{d.name} ({d.width}×{d.height})</option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="text-sm text-neutral-400">Target</span>
+        <select className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                value={target} onChange={(e) => setTarget(e.target.value as "draft" | "live")}>
+          <option value="draft">Draft (safe — won't affect the device yet)</option>
+          <option value="live">Live (replaces the device's current layout)</option>
+        </select>
+      </label>
+      <div className="flex gap-2">
+        <button onClick={apply} disabled={busy} className="btn btn-primary">{busy ? "Applying…" : "Apply"}</button>
+      </div>
+      {msg && <div className="text-sm">{msg}</div>}
+    </div>
+  );
+}

--- a/app/layouts/[id]/page.tsx
+++ b/app/layouts/[id]/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ObjectId } from "mongodb";
+import { layouts, devices } from "@/lib/mongo";
+import ApplyToDevice from "./ApplyToDevice";
+
+export const dynamic = "force-dynamic";
+
+export default async function LayoutDetailPage({ params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) notFound();
+  const lcol = await layouts();
+  const doc = await lcol.findOne({ _id: new ObjectId(params.id) });
+  if (!doc) notFound();
+  const dcol = await devices();
+  const deviceList = (await dcol.find({}, { projection: { name: 1, slug: 1, width: 1, height: 1 } }).toArray())
+    .map((d) => ({ _id: String(d._id), name: d.name, slug: d.slug, width: d.width, height: d.height }));
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{doc.name}</h1>
+          <div className="text-xs text-neutral-500">{doc.width}×{doc.height} · {doc.layout?.length ?? 0} blocks</div>
+        </div>
+        <Link href="/layouts" className="text-sm text-neutral-400 hover:text-emerald-400">← All layouts</Link>
+      </div>
+      <ApplyToDevice layoutId={String(doc._id)} devices={deviceList} />
+    </div>
+  );
+}

--- a/app/layouts/page.tsx
+++ b/app/layouts/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { layouts } from "@/lib/mongo";
+
+export const dynamic = "force-dynamic";
+
+export default async function LayoutsPage() {
+  let list: any[] = [];
+  let error: string | null = null;
+  try {
+    const col = await layouts();
+    list = (await col.find({}).sort({ updatedAt: -1 }).toArray()).map((d) => ({ ...d, _id: String(d._id) }));
+  } catch (e: any) {
+    error = e.message;
+  }
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Layout templates</h1>
+      </div>
+      <p className="text-sm text-neutral-400 mb-4">
+        Save a device's layout as a reusable template, then apply it to any device's draft. Useful for designing on a staging device, then rolling out to real signage.
+      </p>
+      {error && <div className="card border-red-700 text-red-300">{error}</div>}
+      {list.length === 0 && !error && (
+        <div className="card text-neutral-400">
+          No templates yet. From a device editor, click "Save layout as template".
+        </div>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {list.map((l) => (
+          <Link key={l._id} href={`/layouts/${l._id}`} className="card hover:border-emerald-500">
+            <div className="flex items-baseline justify-between">
+              <div className="font-medium">{l.name}</div>
+              <div className="text-xs text-neutral-500">{l.width}×{l.height}</div>
+            </div>
+            <div className="text-xs text-neutral-500 mt-1">{l.layout?.length ?? 0} blocks</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/media/MediaUploadButton.tsx
+++ b/app/media/MediaUploadButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+// Direct uploader for the library — uses the existing crop/dither pipeline
+// from the device editor only when invoked from a block, so this path
+// just stores the source image as-is. The block editor handles 1-bit
+// preparation itself.
+export default function MediaUploadButton() {
+  const router = useRouter();
+  const input = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setBusy(true);
+    try {
+      const dataUrl = await fileToDataUrl(file);
+      const dims = await loadDims(dataUrl);
+      const res = await fetch("/api/media", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: file.name, dataUrl, width: dims.w, height: dims.h }),
+      });
+      if (!res.ok) throw new Error("upload failed");
+      router.refresh();
+    } catch (err) {
+      console.error(err);
+      alert("Upload failed");
+    } finally {
+      setBusy(false);
+      if (input.current) input.current.value = "";
+    }
+  }
+
+  return (
+    <div>
+      <button onClick={() => input.current?.click()} disabled={busy} className="btn btn-primary">
+        {busy ? "Uploading…" : "+ Upload"}
+      </button>
+      <input
+        ref={input}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={onPick}
+      />
+    </div>
+  );
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((res, rej) => {
+    const r = new FileReader();
+    r.onload = () => res(String(r.result));
+    r.onerror = rej;
+    r.readAsDataURL(file);
+  });
+}
+
+function loadDims(src: string): Promise<{ w: number; h: number }> {
+  return new Promise((res) => {
+    const img = new Image();
+    img.onload = () => res({ w: img.naturalWidth, h: img.naturalHeight });
+    img.onerror = () => res({ w: 0, h: 0 });
+    img.src = src;
+  });
+}

--- a/app/media/page.tsx
+++ b/app/media/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { listMedia } from "@/lib/media";
+import MediaUploadButton from "./MediaUploadButton";
+
+export const dynamic = "force-dynamic";
+
+export default async function MediaPage({ searchParams }: { searchParams: { kind?: string } }) {
+  const kind = (searchParams.kind === "upload" || searchParams.kind === "generated")
+    ? searchParams.kind as "upload" | "generated"
+    : undefined;
+  let items: any[] = [];
+  let error: string | null = null;
+  try {
+    items = (await listMedia({ kind, limit: 200 })).map((m) => ({ ...m, _id: String(m._id) }));
+  } catch (e: any) {
+    error = e.message;
+  }
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Media library</h1>
+        <MediaUploadButton />
+      </div>
+      <div className="flex gap-3 mb-4 text-sm">
+        <Link href="/media" className={!kind ? "text-emerald-400" : "text-neutral-400"}>All</Link>
+        <Link href="/media?kind=upload" className={kind === "upload" ? "text-emerald-400" : "text-neutral-400"}>Uploads</Link>
+        <Link href="/media?kind=generated" className={kind === "generated" ? "text-emerald-400" : "text-neutral-400"}>Generated</Link>
+      </div>
+      {error && <div className="card border-red-700 text-red-300">{error}</div>}
+      {items.length === 0 && !error && <div className="card text-neutral-400">Empty. Upload an image or run a plugin.</div>}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        {items.map((m) => (
+          <div key={m._id} className="card">
+            <div className="border border-neutral-800 bg-white">
+              <img src={`/api/media/${m._id}`} alt={m.name ?? ""} className="w-full h-auto pixelated" />
+            </div>
+            <div className="text-xs mt-2">
+              <div className="font-medium truncate">{m.name ?? m._id}</div>
+              <div className="text-neutral-500">{m.kind} · {m.width}×{m.height}</div>
+              <div className="text-neutral-600 font-mono mt-1">{m._id}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/plugins/[id]/PluginEditor.tsx
+++ b/app/plugins/[id]/PluginEditor.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+// Instance editor. Settings are edited as raw JSON for v1 — a generated
+// schema-form is a Phase 2.5 improvement. The runner validates settings
+// server-side anyway, so we just need a way to get JSON in.
+export default function PluginEditor({
+  inst,
+  typeDescription,
+  defaults,
+}: {
+  inst: any;
+  typeDescription: string;
+  defaults: { ttlSec: number; w: number; h: number };
+}) {
+  const router = useRouter();
+  const [name, setName] = useState<string>(inst.name);
+  const [width, setWidth] = useState<number>(inst.width);
+  const [height, setHeight] = useState<number>(inst.height);
+  const [ttlSec, setTtlSec] = useState<number>(inst.ttlSec ?? defaults.ttlSec);
+  const [settingsText, setSettingsText] = useState<string>(JSON.stringify(inst.settings ?? {}, null, 2));
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [preview, setPreview] = useState<number>(Date.now());
+  const [lastError, setLastError] = useState<any>(inst.lastError ?? null);
+
+  async function save() {
+    setBusy(true);
+    setErr(null);
+    let settings: unknown;
+    try {
+      settings = JSON.parse(settingsText);
+    } catch (e: any) {
+      setErr(`Settings JSON: ${e.message}`);
+      setBusy(false);
+      return;
+    }
+    try {
+      const r = await fetch(`/api/plugins/instances/${inst._id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, width, height, ttlSec, settings }),
+      });
+      if (!r.ok) throw new Error((await r.json()).error ?? "save failed");
+      setPreview(Date.now());
+    } catch (e: any) {
+      setErr(e.message);
+    }
+    setBusy(false);
+  }
+
+  async function refresh() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch(`/api/plugins/instances/${inst._id}/refresh`, { method: "POST" });
+      if (!r.ok) throw new Error((await r.json()).error ?? "refresh failed");
+      const d = await r.json();
+      setLastError(d.lastError ?? null);
+      setPreview(Date.now());
+    } catch (e: any) {
+      setErr(e.message);
+    }
+    setBusy(false);
+  }
+
+  async function destroy() {
+    if (!confirm("Delete this plugin instance? Devices that reference it will render nothing where it lived.")) return;
+    setBusy(true);
+    try {
+      await fetch(`/api/plugins/instances/${inst._id}`, { method: "DELETE" });
+      router.push("/plugins");
+    } catch (e: any) {
+      setErr(e.message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="space-y-4">
+        <div className="text-sm text-neutral-400">{typeDescription}</div>
+        <label className="block">
+          <span className="text-sm text-neutral-400">Name</span>
+          <input className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                 value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <div className="grid grid-cols-3 gap-2">
+          <label className="block">
+            <span className="text-sm text-neutral-400">Width</span>
+            <input type="number" className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                   value={width} onChange={(e) => setWidth(Number(e.target.value))} />
+          </label>
+          <label className="block">
+            <span className="text-sm text-neutral-400">Height</span>
+            <input type="number" className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                   value={height} onChange={(e) => setHeight(Number(e.target.value))} />
+          </label>
+          <label className="block">
+            <span className="text-sm text-neutral-400">TTL (sec)</span>
+            <input type="number" className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+                   value={ttlSec} onChange={(e) => setTtlSec(Number(e.target.value))} />
+          </label>
+        </div>
+        <label className="block">
+          <span className="text-sm text-neutral-400">Settings (JSON)</span>
+          <textarea
+            className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2 font-mono text-xs"
+            rows={18}
+            value={settingsText}
+            onChange={(e) => setSettingsText(e.target.value)}
+          />
+        </label>
+        {err && <div className="text-sm text-red-400">{err}</div>}
+        <div className="flex gap-2">
+          <button onClick={save} disabled={busy} className="btn btn-primary">Save</button>
+          <button onClick={refresh} disabled={busy} className="btn">Refresh now</button>
+          <button onClick={destroy} disabled={busy} className="btn text-red-400">Delete</button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="text-sm text-neutral-400">Latest render ({width}×{height})</div>
+        <div className="border border-neutral-800 bg-white inline-block">
+          <img
+            src={`/api/plugins/instances/${inst._id}/preview.png?t=${preview}`}
+            alt=""
+            style={{ width: "100%", maxWidth: 600 }}
+            className="pixelated"
+          />
+        </div>
+        {lastError && (
+          <div className="card border-red-700 text-red-300 text-sm">
+            <div className="font-medium">Last error</div>
+            <div className="font-mono text-xs mt-1">{lastError.message}</div>
+            <div className="text-xs text-neutral-500 mt-1">{new Date(lastError.at).toLocaleString()}</div>
+          </div>
+        )}
+        <div className="text-xs text-neutral-500">
+          To use this plugin, open a device's layout editor and add a <em>plugin</em> block pointing at this instance.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/plugins/[id]/page.tsx
+++ b/app/plugins/[id]/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ObjectId } from "mongodb";
+import { pluginInstances } from "@/lib/mongo";
+import { getPluginType } from "@/lib/plugins/registry";
+import PluginEditor from "./PluginEditor";
+
+export const dynamic = "force-dynamic";
+
+export default async function PluginInstancePage({ params }: { params: { id: string } }) {
+  if (!ObjectId.isValid(params.id)) notFound();
+  const col = await pluginInstances();
+  const doc = await col.findOne({ _id: new ObjectId(params.id) });
+  if (!doc) notFound();
+  const type = getPluginType(doc.typeId);
+  const inst = { ...doc, _id: String(doc._id) };
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{inst.name}</h1>
+          <div className="text-xs text-neutral-500 font-mono">{inst.typeId}</div>
+        </div>
+        <Link href="/plugins" className="text-sm text-neutral-400 hover:text-emerald-400">← All plugins</Link>
+      </div>
+      {!type && (
+        <div className="card border-red-700 text-red-300">
+          Unknown plugin type "{inst.typeId}". The code that defines it may have been removed.
+        </div>
+      )}
+      {type && (
+        <PluginEditor
+          inst={inst}
+          typeDescription={type.description}
+          defaults={{ ttlSec: type.defaultTtlSec, ...type.defaultSize }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/plugins/new/NewPluginForm.tsx
+++ b/app/plugins/new/NewPluginForm.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { PluginTypeMeta } from "@/lib/plugins/types";
+
+export default function NewPluginForm({ types }: { types: PluginTypeMeta[] }) {
+  const router = useRouter();
+  const [typeId, setTypeId] = useState(types[0]?.id ?? "");
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const selected = types.find((t) => t.id === typeId);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selected) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/plugins/instances", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          typeId,
+          name: name || `${selected.name} instance`,
+          width: selected.defaultSize.w,
+          height: selected.defaultSize.h,
+          settings: {},
+          ttlSec: selected.defaultTtlSec,
+        }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "create failed");
+      const created = await res.json();
+      router.push(`/plugins/${created._id}`);
+    } catch (e: any) {
+      setErr(e.message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-2xl">
+      <label className="block">
+        <span className="text-sm text-neutral-400">Type</span>
+        <select
+          className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+          value={typeId}
+          onChange={(e) => setTypeId(e.target.value)}
+        >
+          {types.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name} — {t.id}
+            </option>
+          ))}
+        </select>
+      </label>
+      {selected && (
+        <div className="text-sm text-neutral-400">
+          {selected.description}
+          <div className="text-xs text-neutral-500 mt-1">
+            Default size: {selected.defaultSize.w}×{selected.defaultSize.h} · default TTL: {selected.defaultTtlSec}s
+          </div>
+        </div>
+      )}
+      <label className="block">
+        <span className="text-sm text-neutral-400">Name</span>
+        <input
+          className="block w-full mt-1 bg-neutral-900 border border-neutral-700 rounded px-3 py-2"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={selected?.name ?? ""}
+        />
+      </label>
+      {err && <div className="text-sm text-red-400">{err}</div>}
+      <button type="submit" disabled={busy} className="btn btn-primary">
+        {busy ? "Creating…" : "Create"}
+      </button>
+    </form>
+  );
+}

--- a/app/plugins/new/page.tsx
+++ b/app/plugins/new/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { listPluginTypes } from "@/lib/plugins/registry";
+import NewPluginForm from "./NewPluginForm";
+
+export const dynamic = "force-dynamic";
+
+export default function NewPluginPage() {
+  const types = listPluginTypes();
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">New plugin instance</h1>
+        <Link href="/plugins" className="text-sm text-neutral-400 hover:text-emerald-400">← Back</Link>
+      </div>
+      <NewPluginForm types={types} />
+    </div>
+  );
+}

--- a/app/plugins/page.tsx
+++ b/app/plugins/page.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { pluginInstances } from "@/lib/mongo";
+import { listPluginTypes } from "@/lib/plugins/registry";
+
+export const dynamic = "force-dynamic";
+
+export default async function PluginsPage() {
+  let list: any[] = [];
+  let error: string | null = null;
+  try {
+    const col = await pluginInstances();
+    list = (await col.find({}).sort({ updatedAt: -1 }).toArray()).map((d) => ({ ...d, _id: String(d._id) }));
+  } catch (e: any) {
+    error = e.message;
+  }
+  const types = listPluginTypes();
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-semibold">Plugins</h1>
+        <Link href="/plugins/new" className="btn btn-primary">+ New plugin</Link>
+      </div>
+      <p className="text-sm text-neutral-400 mb-4">
+        Plugins pull data from Wildmile MongoDB, an HTTP API, or Claude, render an SVG, and cache the rasterised result.
+        Place a plugin block in any device layout to use one. Refresh respects each instance's TTL.
+      </p>
+      {error && <div className="card border-red-700 text-red-300 mb-4">{error}</div>}
+
+      {list.length === 0 && !error && (
+        <div className="card text-neutral-400 mb-6">
+          No plugin instances yet. Pick a type below to create your first one.
+        </div>
+      )}
+
+      {list.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+          {list.map((p) => (
+            <Link key={p._id} href={`/plugins/${p._id}`} className="card hover:border-emerald-500">
+              <div className="flex items-baseline justify-between">
+                <div className="font-medium">{p.name}</div>
+                <div className="text-xs text-neutral-500">{p.width}×{p.height}</div>
+              </div>
+              <div className="text-xs text-neutral-500 font-mono mt-1">{p.typeId}</div>
+              <div className="mt-3 rounded overflow-hidden border border-neutral-800 bg-white">
+                <img
+                  src={`/api/plugins/instances/${p._id}/preview.png?t=${new Date(p.updatedAt).getTime()}`}
+                  alt=""
+                  className="w-full h-auto pixelated"
+                />
+              </div>
+              {p.lastError && (
+                <div className="mt-2 text-xs text-red-400 line-clamp-2">{p.lastError.message}</div>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <h2 className="text-lg font-semibold mb-2">Available types</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 text-sm">
+        {types.map((t) => (
+          <div key={t.id} className="card">
+            <div className="font-medium">{t.name}</div>
+            <div className="text-xs text-neutral-500 font-mono">{t.id}</div>
+            <div className="text-xs text-neutral-400 mt-2">{t.description}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/DeviceEditor.tsx
+++ b/components/DeviceEditor.tsx
@@ -9,9 +9,10 @@ import LayoutEditor from "./LayoutEditor";
 type Props = {
   device: any;
   assets: any[];
+  plugins?: any[];
 };
 
-export default function DeviceEditor({ device, assets }: Props) {
+export default function DeviceEditor({ device, assets, plugins = [] }: Props) {
   const router = useRouter();
   const [name, setName] = useState(device.name);
   const [slug, setSlug] = useState(device.slug);
@@ -20,7 +21,12 @@ export default function DeviceEditor({ device, assets }: Props) {
   const [rotation, setRotation] = useState(device.rotation ?? 0);
   const [bitDepth, setBitDepth] = useState<1 | 24>(device.bitDepth === 24 ? 24 : 1);
   const [background, setBackground] = useState<"white" | "black">(device.background === "white" ? "white" : "black");
-  const [layout, setLayout] = useState<Block[]>(device.layout ?? []);
+  // We edit a "working" layout that the user sees. If a draft exists, we
+  // load that — otherwise the live layout. Saving writes back to draft
+  // when one exists or the user has clicked "Edit as draft", else live.
+  const initialIsDraft = Array.isArray(device.draftLayout) && device.draftLayout.length > 0;
+  const [isDraftMode, setIsDraftMode] = useState<boolean>(initialIsDraft);
+  const [layout, setLayout] = useState<Block[]>(initialIsDraft ? device.draftLayout : (device.layout ?? []));
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState<null | Date>(null);
   const [err, setErr] = useState<string | null>(null);
@@ -31,10 +37,15 @@ export default function DeviceEditor({ device, assets }: Props) {
   async function save() {
     setSaving(true);
     setErr(null);
+    const body: Record<string, unknown> = { name, slug, width, height, rotation, bitDepth, background };
+    // Draft mode writes to draftLayout and leaves the live layout alone —
+    // so the device in the field keeps serving the old image until publish.
+    if (isDraftMode) body.draftLayout = layout;
+    else body.layout = layout;
     const res = await fetch(`/api/devices/${device._id}`, {
       method: "PATCH",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name, slug, width, height, rotation, bitDepth, background, layout }),
+      body: JSON.stringify(body),
     });
     setSaving(false);
     if (!res.ok) {
@@ -43,6 +54,38 @@ export default function DeviceEditor({ device, assets }: Props) {
     }
     setSaved(new Date());
     setPreviewBust(Date.now());
+  }
+
+  async function publishDraft() {
+    if (!confirm("Publish the draft? The live device will start serving this layout on its next pull.")) return;
+    setSaving(true);
+    setErr(null);
+    const res = await fetch(`/api/devices/${device._id}/publish`, { method: "POST" });
+    setSaving(false);
+    if (!res.ok) {
+      setErr("Publish failed");
+      return;
+    }
+    setIsDraftMode(false);
+    setPreviewBust(Date.now());
+    router.refresh();
+  }
+
+  async function saveAsTemplate() {
+    const tplName = prompt("Template name?", `${name} template`);
+    if (!tplName) return;
+    setSaving(true);
+    const res = await fetch("/api/layouts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: tplName, width, height, background, layout }),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      setErr("Save-as-template failed");
+      return;
+    }
+    setSaved(new Date());
   }
 
   async function del() {
@@ -58,11 +101,19 @@ export default function DeviceEditor({ device, assets }: Props) {
           <h1 className="text-2xl font-semibold">{name}</h1>
           <div className="text-sm text-neutral-500 font-mono">{origin}/{slug}/current.bmp</div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
           <Link href="/" className="btn">Back</Link>
           <button className="btn btn-danger" onClick={del}>Delete</button>
+          <button className="btn" onClick={saveAsTemplate} disabled={saving}>Save as template</button>
+          <label className="flex items-center gap-1 text-xs text-neutral-400">
+            <input type="checkbox" checked={isDraftMode} onChange={(e) => setIsDraftMode(e.target.checked)} />
+            Draft mode
+          </label>
+          {isDraftMode && (
+            <button className="btn" onClick={publishDraft} disabled={saving}>Publish</button>
+          )}
           <button className="btn btn-primary" onClick={save} disabled={saving}>
-            {saving ? "Saving…" : "Save"}
+            {saving ? "Saving…" : isDraftMode ? "Save draft" : "Save"}
           </button>
         </div>
       </div>
@@ -117,6 +168,7 @@ export default function DeviceEditor({ device, assets }: Props) {
             height={editH}
             initialLayout={layout}
             assets={assets}
+            plugins={plugins}
             onChange={setLayout}
           />
         </div>

--- a/components/LayoutEditor.tsx
+++ b/components/LayoutEditor.tsx
@@ -5,12 +5,14 @@ import { PRESET_BLOCKS, gridBlocks, newBlock } from "@/lib/block";
 import ImageProcessor from "./ImageProcessor";
 
 type Asset = { _id: string; name: string; width: number; height: number; variables?: { key: string; label?: string; type: string; default?: string }[] };
+type PluginInstance = { _id: string; name: string; typeId: string; width: number; height: number };
 
 type Props = {
   width: number;
   height: number;
   initialLayout: Block[];
   assets: Asset[];
+  plugins?: PluginInstance[];
   onChange: (blocks: Block[]) => void;
 };
 
@@ -18,7 +20,7 @@ const SNAP = 2;
 const MAX_DISPLAY_W = 900;
 const MAX_DISPLAY_H = 700;
 
-export default function LayoutEditor({ width, height, initialLayout, assets, onChange }: Props) {
+export default function LayoutEditor({ width, height, initialLayout, assets, plugins = [], onChange }: Props) {
   const [blocks, setBlocks] = useState<Block[]>(initialLayout);
   const [selected, setSelected] = useState<string | null>(null);
   const [showImage, setShowImage] = useState(false);
@@ -61,6 +63,13 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
     const a = assets.find((x) => x._id === assetId);
     if (!a) return;
     add(newBlock({ type: "asset", assetId, x: 10, y: 10, w: a.width, h: a.height, text: undefined }));
+  }
+  function addPluginInstance(pluginInstanceId: string) {
+    const p = plugins.find((x) => x._id === pluginInstanceId);
+    if (!p) return;
+    // Default the block to the instance's native pixel size so its image
+    // doesn't get resampled. Designers can resize after.
+    add(newBlock({ type: "plugin", pluginInstanceId, x: 10, y: 10, w: p.width, h: p.height, text: undefined }));
   }
   function addFullFill() {
     // Solid block covering the whole canvas, dropped at the back of the
@@ -105,6 +114,12 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
               {assets.map((a) => <option key={a._id} value={a._id}>{a.name} ({a.width}×{a.height})</option>)}
             </select>
           )}
+          {plugins.length > 0 && (
+            <select className="input max-w-[220px]" onChange={(e) => { if (e.target.value) addPluginInstance(e.target.value); e.target.value = ""; }} defaultValue="">
+              <option value="">+ Plugin…</option>
+              {plugins.map((p) => <option key={p._id} value={p._id}>{p.name} ({p.typeId})</option>)}
+            </select>
+          )}
           <span className="mx-2 text-neutral-600">|</span>
           <button className="btn" onClick={() => addGrid(2, 2)}>Grid 2×2</button>
           <button className="btn" onClick={() => addGrid(3, 2)}>Grid 3×2</button>
@@ -134,6 +149,7 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
               onSelect={() => setSelected(b.id)}
               onUpdate={(patch) => update(b.id, patch)}
               assets={assets}
+              plugins={plugins}
             />
           ))}
         </div>
@@ -149,6 +165,7 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
           <BlockInspector
             block={selectedBlock}
             assets={assets}
+            plugins={plugins}
             canvasW={width}
             canvasH={height}
             onUpdate={(p) => update(selectedBlock.id, p)}
@@ -182,12 +199,13 @@ export default function LayoutEditor({ width, height, initialLayout, assets, onC
 }
 
 function BlockView({
-  block, scale, canvasW, canvasH, selected, onSelect, onUpdate, assets,
+  block, scale, canvasW, canvasH, selected, onSelect, onUpdate, assets, plugins,
 }: {
   block: Block; scale: number; canvasW: number; canvasH: number;
   selected: boolean; onSelect: () => void;
   onUpdate: (p: Partial<Block>) => void;
   assets: Asset[];
+  plugins: PluginInstance[];
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const mode = useRef<"move" | "resize" | null>(null);
@@ -297,6 +315,14 @@ function BlockView({
         <div className={`${block.lineColor === "white" ? "bg-white border border-neutral-400" : "bg-black"} ${block.lineDirection === "vertical" ? "w-[2px] h-full mx-auto" : "h-[2px] w-full my-auto"}`} />
       ) : block.type === "shape" ? (
         <div className={`w-full h-full ${block.shapeKind === "filled" ? "bg-black" : "border-2 border-black"}`} />
+      ) : block.type === "plugin" ? (
+        block.pluginInstanceId
+          ? <img
+              src={`/api/plugins/instances/${block.pluginInstanceId}/preview.png?t=${block.id}`}
+              alt=""
+              className="w-full h-full pixelated object-contain bg-white"
+            />
+          : <div className="w-full h-full flex items-center justify-center text-[10px] bg-neutral-200 text-neutral-500">no plugin selected</div>
       ) : (
         <div>{block.text}</div>
       )}
@@ -324,9 +350,9 @@ function cssFontFamily(family: FontFamily | undefined): string {
 }
 
 function BlockInspector({
-  block, assets, canvasW, canvasH, onUpdate, onRemove, onDuplicate, onEditImage, onReorder,
+  block, assets, plugins, canvasW, canvasH, onUpdate, onRemove, onDuplicate, onEditImage, onReorder,
 }: {
-  block: Block; assets: Asset[]; canvasW: number; canvasH: number;
+  block: Block; assets: Asset[]; plugins: PluginInstance[]; canvasW: number; canvasH: number;
   onUpdate: (p: Partial<Block>) => void;
   onRemove: () => void;
   onDuplicate: () => void;
@@ -365,6 +391,7 @@ function BlockInspector({
           <option value="date">Date / time</option>
           <option value="line">Line</option>
           <option value="shape">Shape</option>
+          <option value="plugin">Plugin</option>
         </select>
       </div>
 
@@ -413,6 +440,7 @@ function BlockInspector({
       {block.type === "date" && <DateFields block={block} onUpdate={onUpdate} />}
       {block.type === "line" && <LineFields block={block} onUpdate={onUpdate} />}
       {block.type === "shape" && <ShapeFields block={block} onUpdate={onUpdate} />}
+      {block.type === "plugin" && <PluginFields block={block} plugins={plugins} onUpdate={onUpdate} />}
 
       {block.type !== "line" && block.type !== "shape" && (
         <div className="grid grid-cols-2 gap-2">
@@ -433,7 +461,43 @@ function titleFor(b: Block): string {
     date: "Date / time",
     line: "Line",
     shape: "Shape",
+    plugin: "Plugin block",
   } as const)[b.type] ?? "Block";
+}
+
+function PluginFields({ block, plugins, onUpdate }: { block: Block; plugins: PluginInstance[]; onUpdate: (p: Partial<Block>) => void }) {
+  const current = plugins.find((p) => p._id === block.pluginInstanceId);
+  return (
+    <div className="space-y-2">
+      <div>
+        <label className="label">Plugin instance</label>
+        <select
+          className="input"
+          value={block.pluginInstanceId ?? ""}
+          onChange={(e) => {
+            const id = e.target.value || undefined;
+            const p = plugins.find((x) => x._id === id);
+            // Snapping w/h to the plugin's native size avoids resampling the cached PNG.
+            onUpdate(p ? { pluginInstanceId: id, w: p.width, h: p.height } : { pluginInstanceId: undefined });
+          }}
+        >
+          <option value="">— pick one —</option>
+          {plugins.map((p) => <option key={p._id} value={p._id}>{p.name} ({p.typeId})</option>)}
+        </select>
+      </div>
+      {current && (
+        <div className="text-xs text-neutral-500">
+          Native size {current.width}×{current.height}.{" "}
+          <a className="text-emerald-400 underline" href={`/plugins/${current._id}`} target="_blank">Edit plugin →</a>
+        </div>
+      )}
+      {!plugins.length && (
+        <div className="text-xs text-neutral-500">
+          No plugins yet. <a className="text-emerald-400 underline" href="/plugins/new" target="_blank">Create one →</a>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function NumField({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {

--- a/lib/block.ts
+++ b/lib/block.ts
@@ -26,6 +26,7 @@ export const PRESET_BLOCKS: Record<string, () => Block> = {
   lineV: () => newBlock({ type: "line", w: 4, h: 200, lineDirection: "vertical", lineThickness: 2, text: undefined }),
   shape: () => newBlock({ type: "shape", w: 120, h: 40, shapeKind: "outlined", lineThickness: 2, text: undefined }),
   fill: () => newBlock({ type: "shape", w: 200, h: 40, shapeKind: "filled", text: undefined }),
+  plugin: () => newBlock({ type: "plugin", w: 480, h: 320, text: undefined }),
 };
 
 export function gridBlocks(rect: { x: number; y: number; w: number; h: number }, cols: number, rows: number, gap = 0): Block[] {

--- a/lib/media.ts
+++ b/lib/media.ts
@@ -1,0 +1,58 @@
+import { ObjectId } from "mongodb";
+import { media, MediaItemDoc } from "./mongo";
+
+export async function saveMedia(
+  item: Omit<MediaItemDoc, "_id" | "createdAt">
+): Promise<MediaItemDoc> {
+  const col = await media();
+  const doc: MediaItemDoc = { ...item, createdAt: new Date() };
+  const r = await col.insertOne(doc as MediaItemDoc);
+  return { ...doc, _id: r.insertedId };
+}
+
+export async function getMedia(id: string): Promise<MediaItemDoc | null> {
+  if (!ObjectId.isValid(id)) return null;
+  const col = await media();
+  return col.findOne({ _id: new ObjectId(id) });
+}
+
+export async function listMedia(opts: {
+  kind?: MediaItemDoc["kind"];
+  sourcePluginId?: string;
+  limit?: number;
+} = {}): Promise<MediaItemDoc[]> {
+  const col = await media();
+  const q: Record<string, unknown> = {};
+  if (opts.kind) q.kind = opts.kind;
+  if (opts.sourcePluginId) q.sourcePluginId = opts.sourcePluginId;
+  return col
+    .find(q)
+    .sort({ createdAt: -1 })
+    .limit(opts.limit ?? 200)
+    .toArray();
+}
+
+export async function deleteMedia(id: string): Promise<void> {
+  if (!ObjectId.isValid(id)) return;
+  const col = await media();
+  await col.deleteOne({ _id: new ObjectId(id) });
+}
+
+// Convenience: turn a raw PNG buffer into a base64 data URL suitable for
+// storing on a MediaItemDoc (matches the existing image-block format).
+export function pngBufferToDataUrl(buf: Buffer): string {
+  return `data:image/png;base64,${buf.toString("base64")}`;
+}
+
+// Strip the `data:...;base64,` prefix and return the raw bytes. Useful when
+// we want to push the same bytes into canvas drawImage.
+export function dataUrlToBuffer(dataUrl: string): Buffer {
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0) throw new Error("invalid data URL");
+  const meta = dataUrl.slice(5, comma); // strip leading "data:"
+  const isBase64 = /;base64$/i.test(meta);
+  const payload = dataUrl.slice(comma + 1);
+  return isBase64
+    ? Buffer.from(payload, "base64")
+    : Buffer.from(decodeURIComponent(payload), "utf8");
+}

--- a/lib/mongo.ts
+++ b/lib/mongo.ts
@@ -32,6 +32,15 @@ export async function devices(): Promise<Collection<DeviceDoc>> {
 export async function assets(): Promise<Collection<AssetDoc>> {
   return (await getDb()).collection<AssetDoc>("assets");
 }
+export async function pluginInstances(): Promise<Collection<PluginInstanceDoc>> {
+  return (await getDb()).collection<PluginInstanceDoc>("plugin_instances");
+}
+export async function media(): Promise<Collection<MediaItemDoc>> {
+  return (await getDb()).collection<MediaItemDoc>("media");
+}
+export async function layouts(): Promise<Collection<LayoutDoc>> {
+  return (await getDb()).collection<LayoutDoc>("layouts");
+}
 
 export { ObjectId };
 
@@ -43,7 +52,8 @@ export type BlockType =
   | "qr"
   | "date"
   | "line"
-  | "shape";
+  | "shape"
+  | "plugin";
 
 export type FontFamily = "mono" | "sans" | "houschka" | "houschka-bold" | "houschka-demibold" | "houschka-extrabold" | "pixelva" | "chikarego";
 
@@ -123,6 +133,12 @@ export type Block = {
 
   // shape
   shapeKind?: "filled" | "outlined";
+
+  // plugin
+  pluginInstanceId?: string;        // references PluginInstanceDoc._id
+  // image-block extension: when set, drawImage resolves a MediaItem instead
+  // of using the inline data-URL imageData. Old data-URL blocks keep working.
+  mediaId?: string;
 };
 
 export type AssetVariable = {
@@ -145,6 +161,9 @@ export type DeviceDoc = {
   // (e.g. the 28" 3840×1080 panel).
   bitDepth?: 1 | 24;
   layout: Block[];
+  // Optional uncommitted draft. The public pull endpoint always serves
+  // `layout`; the editor edits `draftLayout` and "Publish" copies it across.
+  draftLayout?: Block[];
   updatedAt: Date;
   createdAt: Date;
 };
@@ -159,4 +178,62 @@ export type AssetDoc = {
   variables?: AssetVariable[];
   updatedAt: Date;
   createdAt: Date;
+};
+
+// A configured instance of a code-defined plugin type. The type itself lives
+// in lib/plugins/types/<id>.ts; settings are validated by that type's zod
+// schema at fetch time.
+export type PluginInstanceDoc = {
+  _id?: ObjectId;
+  typeId: string;                  // e.g. "custom-svg", "plant-heatmap"
+  name: string;
+  width: number;
+  height: number;
+  settings: Record<string, unknown>;
+  ttlSec: number;                  // refresh interval (regenerate-on-pull cap)
+  // Last successful fetch timestamp. We use this as the TTL anchor.
+  lastRunAt?: Date;
+  // Hash of the most recent fetched data payload — skip re-rendering when
+  // unchanged, even if TTL is exceeded.
+  lastDataHash?: string;
+  // Most recently generated media item for this instance. Block render
+  // path reads this id and composites the image.
+  latestMediaId?: string;
+  // Surface fetch/render errors to the CMS without crashing the device pull.
+  lastError?: { at: Date; message: string };
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+// Generic media store — uploads (user-cropped/dithered images) and plugin
+// outputs share one collection so the library UI can list both.
+export type MediaItemDoc = {
+  _id?: ObjectId;
+  kind: "upload" | "generated";
+  name?: string;
+  mimeType: string;                // "image/png", "image/svg+xml", "image/jpeg"
+  width: number;
+  height: number;
+  // v1 stores image bytes inline as a data URL — same as existing image
+  // blocks. The storageRef escape hatch is reserved for a later move to
+  // blob storage without touching call sites.
+  dataUrl?: string;
+  storageRef?: string;
+  // Provenance for generated items.
+  sourcePluginId?: string;
+  sourceDataHash?: string;
+  createdAt: Date;
+};
+
+// A named, reusable layout independent of any device. Applied to a device by
+// copying its blocks (and dimensions) onto the device's draft or live layout.
+export type LayoutDoc = {
+  _id?: ObjectId;
+  name: string;
+  width: number;
+  height: number;
+  background?: "white" | "black";
+  layout: Block[];
+  createdAt: Date;
+  updatedAt: Date;
 };

--- a/lib/plugins/data-sources.ts
+++ b/lib/plugins/data-sources.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+// A small, declarative data-source spec used by plugin SETTINGS so that
+// many plugin types (custom-svg, kpi, list, claude-gen) can share one
+// fetching layer instead of each rolling its own.
+//
+// The Wildmile Mongo connector lives in lib/plugins/wildmile.ts and
+// enforces a read-only collection allowlist.
+
+export const HttpSource = z.object({
+  kind: z.literal("http"),
+  url: z.string().url(),
+  method: z.enum(["GET", "POST"]).optional(),
+  headers: z.record(z.string()).optional(),
+  body: z.string().optional(),
+  // Optional JSON-pointer-ish path into the response. "items.0" → response.items[0].
+  jsonPath: z.string().optional(),
+});
+
+export const MongoWildmileSource = z.object({
+  kind: z.literal("mongo-wildmile"),
+  collection: z.string(),
+  query: z.record(z.unknown()).optional(),
+  projection: z.record(z.union([z.literal(0), z.literal(1)])).optional(),
+  sort: z.record(z.union([z.literal(1), z.literal(-1)])).optional(),
+  limit: z.number().int().positive().max(1000).optional(),
+});
+
+export const StaticSource = z.object({
+  kind: z.literal("static"),
+  value: z.unknown(),
+});
+
+export const DataSourceConfig = z.discriminatedUnion("kind", [
+  HttpSource,
+  MongoWildmileSource,
+  StaticSource,
+]);
+
+export type DataSourceConfig = z.infer<typeof DataSourceConfig>;
+
+export async function fetchDataSource(cfg: DataSourceConfig): Promise<unknown> {
+  switch (cfg.kind) {
+    case "static":
+      return cfg.value;
+    case "http":
+      return fetchHttp(cfg);
+    case "mongo-wildmile": {
+      // Late import so plugin types that don't use Wildmile don't pay the
+      // module-load cost.
+      const { wildmileQuery } = await import("./wildmile");
+      return wildmileQuery(cfg);
+    }
+  }
+}
+
+async function fetchHttp(cfg: z.infer<typeof HttpSource>): Promise<unknown> {
+  const res = await fetch(cfg.url, {
+    method: cfg.method ?? "GET",
+    headers: cfg.headers,
+    body: cfg.body,
+    // Short-circuit Next.js's fetch caching — the plugin runner manages
+    // its own TTL based on lastRunAt.
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} for ${cfg.url}`);
+  }
+  const ct = res.headers.get("content-type") ?? "";
+  let body: unknown;
+  if (ct.includes("application/json")) body = await res.json();
+  else body = await res.text();
+  if (cfg.jsonPath) body = navigatePath(body, cfg.jsonPath);
+  return body;
+}
+
+function navigatePath(obj: unknown, path: string): unknown {
+  const parts = path.split(".").filter(Boolean);
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[/^\d+$/.test(p) ? Number(p) : p];
+  }
+  return cur;
+}

--- a/lib/plugins/registry.ts
+++ b/lib/plugins/registry.ts
@@ -1,0 +1,42 @@
+import type { PluginType, PluginTypeMeta } from "./types";
+
+// Static import barrel — every plugin type registers itself here. Static
+// imports are intentional: Next.js's serverless bundler can't dynamically
+// require() from disk at runtime on Vercel, and we want each deploy to
+// ship a known, audited set of plugin types.
+import { customSvgPlugin } from "./types/custom-svg";
+import { kpiPlugin } from "./types/kpi";
+import { listPlugin } from "./types/list";
+import { plantHeatmapPlugin } from "./types/plant-heatmap";
+import { trashDashboardPlugin } from "./types/trash-dashboard";
+import { eventsPlugin } from "./types/events";
+import { claudeGenPlugin } from "./types/claude-gen";
+
+const ALL: PluginType<any, any>[] = [
+  customSvgPlugin,
+  kpiPlugin,
+  listPlugin,
+  plantHeatmapPlugin,
+  trashDashboardPlugin,
+  eventsPlugin,
+  claudeGenPlugin,
+];
+
+const BY_ID: Record<string, PluginType<any, any>> = Object.fromEntries(
+  ALL.map((p) => [p.id, p])
+);
+
+export function getPluginType(id: string): PluginType<any, any> | undefined {
+  return BY_ID[id];
+}
+
+export function listPluginTypes(): PluginTypeMeta[] {
+  return ALL.map((p) => ({
+    id: p.id,
+    name: p.name,
+    description: p.description,
+    category: p.category,
+    defaultTtlSec: p.defaultTtlSec,
+    defaultSize: p.defaultSize,
+  }));
+}

--- a/lib/plugins/runner.ts
+++ b/lib/plugins/runner.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import { ObjectId } from "mongodb";
+import { pluginInstances, PluginInstanceDoc } from "../mongo";
+import { saveMedia, pngBufferToDataUrl } from "../media";
+import { getPluginType } from "./registry";
+import { svgToPng } from "./svg";
+
+// Best-effort in-process lock to avoid concurrent regen of the same
+// instance during a burst of device pulls. On serverless cold starts each
+// invocation gets its own map, so this is "good enough" rather than a
+// distributed lock — TTLs are minutes, not milliseconds.
+const inflight = new Map<string, Promise<PluginInstanceDoc | null>>();
+
+export async function ensureFreshOutput(instanceId: string): Promise<PluginInstanceDoc | null> {
+  if (!ObjectId.isValid(instanceId)) return null;
+  if (inflight.has(instanceId)) return inflight.get(instanceId)!;
+
+  const p = runInstance(instanceId).finally(() => inflight.delete(instanceId));
+  inflight.set(instanceId, p);
+  return p;
+}
+
+// Force-refresh regardless of TTL. Used by the CMS "Refresh now" button and
+// during plugin development.
+export async function forceRefresh(instanceId: string): Promise<PluginInstanceDoc | null> {
+  if (!ObjectId.isValid(instanceId)) return null;
+  return runInstance(instanceId, { ignoreTtl: true });
+}
+
+async function runInstance(
+  instanceId: string,
+  opts: { ignoreTtl?: boolean } = {}
+): Promise<PluginInstanceDoc | null> {
+  const col = await pluginInstances();
+  const inst = await col.findOne({ _id: new ObjectId(instanceId) });
+  if (!inst) return null;
+
+  const type = getPluginType(inst.typeId);
+  if (!type) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastError: { at: new Date(), message: `unknown plugin type ${inst.typeId}` } } }
+    );
+    return inst;
+  }
+
+  // TTL gate.
+  const now = new Date();
+  const ttlMs = (inst.ttlSec ?? type.defaultTtlSec) * 1000;
+  if (!opts.ignoreTtl && inst.lastRunAt && now.getTime() - inst.lastRunAt.getTime() < ttlMs) {
+    return inst;
+  }
+
+  // Validate settings against the plugin's schema. Bad settings shouldn't
+  // crash the device pull — record the error, fall back to whatever media
+  // was last successfully generated.
+  const parsed = type.settingsSchema.safeParse(inst.settings);
+  if (!parsed.success) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastError: { at: now, message: `settings invalid: ${parsed.error.message}` } } }
+    );
+    return inst;
+  }
+
+  const ctx = {
+    settings: parsed.data,
+    width: inst.width,
+    height: inst.height,
+    now,
+  };
+
+  let data: unknown;
+  try {
+    data = await type.fetchData(ctx);
+  } catch (err) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastError: { at: now, message: `fetch failed: ${(err as Error).message}` } } }
+    );
+    return inst;
+  }
+
+  // Skip rendering when the data hasn't changed since the last successful
+  // run. We still bump lastRunAt so the TTL clock restarts.
+  const hash = hashData(data);
+  if (inst.latestMediaId && hash === inst.lastDataHash) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastRunAt: now, lastError: undefined } }
+    );
+    return { ...inst, lastRunAt: now };
+  }
+
+  let svg: string;
+  try {
+    svg = await type.renderSvg(ctx, data);
+  } catch (err) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastError: { at: now, message: `render failed: ${(err as Error).message}` } } }
+    );
+    return inst;
+  }
+
+  let pngBuf: Buffer;
+  try {
+    pngBuf = svgToPng(svg, inst.width, inst.height);
+  } catch (err) {
+    await col.updateOne(
+      { _id: inst._id },
+      { $set: { lastError: { at: now, message: `rasterise failed: ${(err as Error).message}` } } }
+    );
+    return inst;
+  }
+
+  const mediaDoc = await saveMedia({
+    kind: "generated",
+    name: `${inst.name} @ ${now.toISOString()}`,
+    mimeType: "image/png",
+    width: inst.width,
+    height: inst.height,
+    dataUrl: pngBufferToDataUrl(pngBuf),
+    sourcePluginId: String(inst._id),
+    sourceDataHash: hash,
+  });
+
+  const update: Partial<PluginInstanceDoc> = {
+    lastRunAt: now,
+    lastDataHash: hash,
+    latestMediaId: String(mediaDoc._id),
+    lastError: undefined,
+    updatedAt: now,
+  };
+  await col.updateOne({ _id: inst._id }, { $set: update });
+  return { ...inst, ...update };
+}
+
+function hashData(data: unknown): string {
+  const json = JSON.stringify(data, replacer);
+  return createHash("sha256").update(json).digest("hex");
+}
+
+function replacer(_key: string, value: unknown): unknown {
+  // Normalise Date → ISO so otherwise-identical payloads hash the same
+  // even when fetchData returns Date objects.
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}

--- a/lib/plugins/svg.ts
+++ b/lib/plugins/svg.ts
@@ -1,0 +1,56 @@
+import { Resvg } from "@resvg/resvg-js";
+
+// Rasterise an SVG string to a PNG buffer at the requested pixel size.
+// We pin width via fitTo and let resvg compute height from the SVG's
+// intrinsic aspect — plugins should set viewBox to the requested w×h so
+// the result fills exactly the block dimensions.
+export function svgToPng(svg: string, width: number, height: number): Buffer {
+  // Ensure top-level svg carries explicit width/height/viewBox. Without these
+  // resvg may downscale to the file's intrinsic size; we want the caller's
+  // pixel dimensions to be authoritative.
+  const normalised = ensureSize(svg, width, height);
+  const resvg = new Resvg(normalised, {
+    fitTo: { mode: "width", value: width },
+    background: "rgba(0,0,0,0)",
+    font: { loadSystemFonts: true },
+  });
+  const png = resvg.render().asPng();
+  return Buffer.from(png);
+}
+
+function ensureSize(svg: string, w: number, h: number): string {
+  // Cheap, regex-based rewrite of the opening <svg ...> tag. We're not
+  // parsing arbitrary user XML for correctness here — plugins control their
+  // own output and we trust them to produce valid SVG. The goal is to make
+  // sure width/height/viewBox are present so resvg honors our target size.
+  return svg.replace(/<svg\b([^>]*)>/i, (_full, attrs: string) => {
+    let a = attrs;
+    if (!/\swidth=/i.test(a)) a += ` width="${w}"`;
+    if (!/\sheight=/i.test(a)) a += ` height="${h}"`;
+    if (!/\sviewBox=/i.test(a)) a += ` viewBox="0 0 ${w} ${h}"`;
+    if (!/\sxmlns=/i.test(a)) a += ` xmlns="http://www.w3.org/2000/svg"`;
+    return `<svg${a}>`;
+  });
+}
+
+// Tiny SVG-safe text escape — plugins should use this when interpolating
+// user data into text nodes or attribute values.
+export function svgEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Strip <script> elements and event-handler attributes. Used on any SVG
+// that may have been authored by an external party (claude-gen output,
+// for instance). We don't execute SVG, but resvg does load external refs
+// in some configurations, and we don't want surprises.
+export function sanitiseSvg(svg: string): string {
+  return svg
+    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
+    .replace(/\son\w+="[^"]*"/gi, "")
+    .replace(/\son\w+='[^']*'/gi, "");
+}

--- a/lib/plugins/template.ts
+++ b/lib/plugins/template.ts
@@ -1,0 +1,37 @@
+// Shared {{var}} interpolation used by template-driven plugin types.
+// Mirrors the asset-binding pattern in lib/render.ts (applyVars) but works
+// against an arbitrary record. Supports dotted paths into nested data:
+// `{{ items.0.title }}`.
+
+import { svgEscape } from "./svg";
+
+export type TemplateValues = Record<string, unknown>;
+
+export function interpolate(template: string, values: TemplateValues, opts: { escape?: boolean } = {}): string {
+  const escape = opts.escape !== false;
+  return template.replace(/\{\{\s*([\w.-]+)\s*(\|\s*raw)?\s*\}\}/g, (_full, path: string, rawTag: string | undefined) => {
+    const raw = lookup(values, path);
+    if (raw == null) return "";
+    const s = typeof raw === "string" ? raw : JSON.stringify(raw);
+    if (rawTag) return s;
+    return escape ? svgEscape(s) : s;
+  });
+}
+
+function lookup(obj: unknown, path: string): unknown {
+  const parts = path.split(".");
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[/^\d+$/.test(p) ? Number(p) : p];
+  }
+  return cur;
+}
+
+// Render a per-item snippet repeatedly. Used by the list plugin and any
+// other type that wants a "for each" loop in user-authored SVG.
+export function repeat<T>(items: T[], itemTemplate: string, baseValues: TemplateValues = {}): string {
+  return items
+    .map((item, i) => interpolate(itemTemplate, { ...baseValues, item, i }))
+    .join("");
+}

--- a/lib/plugins/types.ts
+++ b/lib/plugins/types.ts
@@ -1,0 +1,54 @@
+import type { ZodTypeAny } from "zod";
+
+// A plugin TYPE is a code-defined recipe: how to fetch data and how to draw
+// it as an SVG at a given pixel size. INSTANCES of a type (Mongo docs in
+// `plugin_instances`) carry per-deployment settings — different parks,
+// different palettes, different date windows.
+export interface PluginType<TSettings = unknown, TData = unknown> {
+  id: string;
+  name: string;
+  description: string;
+  category: "data-viz" | "list" | "kpi" | "custom" | "ai";
+
+  // Default TTL for new instances. Per-instance ttlSec overrides this.
+  // 900 = 15 min, 86400 = daily, 604800 = weekly.
+  defaultTtlSec: number;
+
+  // Default block dimensions when a new instance is created.
+  defaultSize: { w: number; h: number };
+
+  // Runtime-validated settings shape. The CMS uses this to generate a
+  // settings form and the runner uses it to coerce user-supplied JSON
+  // before calling fetchData/renderSvg. Kept loose (ZodTypeAny) so that
+  // plugin authors can use defaults() and optional() freely without
+  // fighting the input-vs-output type variance.
+  settingsSchema: ZodTypeAny;
+
+  // Build whatever payload the renderer needs. May call external HTTP,
+  // MongoDB (eink_cms's own DB or Wildmile), or Claude. Throwing here
+  // records lastError on the instance without crashing the device pull.
+  fetchData(ctx: PluginContext<TSettings>): Promise<TData>;
+
+  // Pure function of (settings, data, size) → SVG string. Kept separate
+  // from fetchData so re-renders can skip the network when only the
+  // block size changes.
+  renderSvg(ctx: PluginContext<TSettings>, data: TData): Promise<string>;
+}
+
+export interface PluginContext<TSettings> {
+  settings: TSettings;
+  width: number;
+  height: number;
+  now: Date;
+}
+
+// Lightweight, untyped reference suitable for the registry index returned
+// from `/api/plugins/types`.
+export interface PluginTypeMeta {
+  id: string;
+  name: string;
+  description: string;
+  category: PluginType["category"];
+  defaultTtlSec: number;
+  defaultSize: { w: number; h: number };
+}

--- a/lib/plugins/types/claude-gen.ts
+++ b/lib/plugins/types/claude-gen.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { DataSourceConfig, fetchDataSource } from "../data-sources";
+import { interpolate } from "../template";
+import { sanitiseSvg, svgEscape } from "../svg";
+
+// Asks Claude to either (a) write the entire SVG itself ("svg" mode), or
+// (b) fill named variables in a user-authored SVG template ("text" mode).
+// Text mode is preferred for park signage where designers want control of
+// layout and Claude's job is just to write copy.
+
+const Settings = z.object({
+  // Anthropic model id. Pinned in settings so a deployment can refresh
+  // without changing model behaviour out from under it.
+  model: z.string().default("claude-haiku-4-5-20251001"),
+  prompt: z.string().min(1),
+  outputKind: z.enum(["svg", "text"]).default("text"),
+  // For "text" mode: an SVG template containing {{var}} placeholders the
+  // model should fill. The prompt should tell the model to return a JSON
+  // object with those keys.
+  svgTemplate: z.string().optional(),
+  // Optional context source — fetched and shown to the model verbatim.
+  context: DataSourceConfig.optional(),
+  // Hard cap so a misconfigured plugin can't burn budget.
+  maxTokens: z.number().int().positive().max(4096).default(1024),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { text: string; values?: Record<string, unknown> };
+
+export const claudeGenPlugin: PluginType<Settings, Data> = {
+  id: "claude-gen",
+  name: "Claude Generator",
+  description: "Generate content with Claude at refresh time. Mode 'text' fills a designer-authored SVG template with variables; mode 'svg' returns the whole SVG.",
+  category: "ai",
+  defaultTtlSec: 86400,
+  defaultSize: { w: 800, h: 480 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error("ANTHROPIC_API_KEY is not set");
+
+    let contextBlock = "";
+    if (ctx.settings.context) {
+      const raw = await fetchDataSource(ctx.settings.context);
+      contextBlock = `\n\nData:\n${JSON.stringify(raw, null, 2).slice(0, 6000)}`;
+    }
+
+    const isText = ctx.settings.outputKind === "text";
+    const userPrompt = isText
+      ? `${ctx.settings.prompt}${contextBlock}\n\nReturn ONLY a JSON object whose keys match the {{variables}} in this SVG template:\n${ctx.settings.svgTemplate ?? ""}`
+      : `${ctx.settings.prompt}${contextBlock}\n\nReturn ONLY a complete <svg ...>...</svg> document sized ${ctx.width}×${ctx.height}, no markdown fences.`;
+
+    // Lazy-load the SDK so plugins that never use Claude don't pay the
+    // load cost.
+    const { default: Anthropic } = await import("@anthropic-ai/sdk");
+    const client = new Anthropic({ apiKey });
+    const res = await client.messages.create({
+      model: ctx.settings.model,
+      max_tokens: ctx.settings.maxTokens,
+      messages: [{ role: "user", content: userPrompt }],
+    });
+    const textBlock = res.content.find((b) => b.type === "text");
+    const text = textBlock && textBlock.type === "text" ? textBlock.text : "";
+
+    if (isText) {
+      // Try to parse Claude's JSON response. If parsing fails we fall back
+      // to a single {error} variable so the SVG can still render.
+      const cleaned = text.replace(/^```json\n?|```$/g, "").trim();
+      try {
+        const values = JSON.parse(cleaned);
+        return { text, values };
+      } catch {
+        return { text, values: { error: "Could not parse Claude response", raw: text } };
+      }
+    }
+    return { text };
+  },
+
+  async renderSvg(ctx, data) {
+    if (ctx.settings.outputKind === "svg") {
+      return sanitiseSvg(data.text);
+    }
+    const template = ctx.settings.svgTemplate ?? defaultTextTemplate(ctx.width, ctx.height);
+    return interpolate(template, data.values ?? {});
+  },
+};
+
+function defaultTextTemplate(w: number, h: number): string {
+  return `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="${w / 2}" y="${h * 0.5}" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="32" fill="#000000">${svgEscape("{{message}}")}</text>
+</svg>`;
+}

--- a/lib/plugins/types/custom-svg.ts
+++ b/lib/plugins/types/custom-svg.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { DataSourceConfig, fetchDataSource } from "../data-sources";
+import { interpolate } from "../template";
+
+// The escape-hatch plugin: paste any SVG with {{var}} placeholders, point
+// it at a data source, and it renders. Most park-sign plugins start life
+// as one of these and only graduate to a dedicated type when they get
+// complex enough to benefit from real code.
+
+const Settings = z.object({
+  svgTemplate: z.string().min(1, "svgTemplate is required"),
+  dataSource: DataSourceConfig.optional(),
+  // Optional inline constants for the template — handy when you don't
+  // need an external data source but want to parameterise text/colours.
+  constants: z.record(z.unknown()).optional(),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { values: Record<string, unknown> };
+
+export const customSvgPlugin: PluginType<Settings, Data> = {
+  id: "custom-svg",
+  name: "Custom SVG",
+  description: "Paste an SVG template with {{var}} placeholders and bind it to a data source. Best starting point for hand-designed plugins.",
+  category: "custom",
+  defaultTtlSec: 900,
+  defaultSize: { w: 800, h: 480 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const values: Record<string, unknown> = { ...(ctx.settings.constants ?? {}) };
+    if (ctx.settings.dataSource) {
+      const raw = await fetchDataSource(ctx.settings.dataSource);
+      // Two common shapes: an object becomes the variable bag directly;
+      // anything else becomes `data` for `{{data}}` access.
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        Object.assign(values, raw as Record<string, unknown>);
+      } else {
+        values.data = raw;
+      }
+    }
+    values.width = ctx.width;
+    values.height = ctx.height;
+    values.now = ctx.now.toISOString();
+    return { values };
+  },
+
+  async renderSvg(ctx, data) {
+    return interpolate(ctx.settings.svgTemplate, data.values);
+  },
+};

--- a/lib/plugins/types/events.ts
+++ b/lib/plugins/types/events.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { upcomingEvents, UpcomingEvent } from "../wildmile";
+import { svgEscape } from "../svg";
+
+// Upcoming-events panel. Designed for park-sign use — a small handful of
+// upcoming items with date pulled out big, title prominent, optional
+// subtitle and location underneath.
+
+const Settings = z.object({
+  max: z.number().int().positive().max(20).default(4),
+  title: z.string().default("Upcoming"),
+  background: z.enum(["white", "black"]).default("white"),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { events: UpcomingEvent[] };
+
+export const eventsPlugin: PluginType<Settings, Data> = {
+  id: "events",
+  name: "Upcoming Events",
+  description: "Wildmile upcoming-events panel. Big date, event title, optional location.",
+  category: "list",
+  defaultTtlSec: 1800,
+  defaultSize: { w: 960, h: 720 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    return { events: await upcomingEvents({ limit: ctx.settings.max }) };
+  },
+
+  async renderSvg(ctx, data) {
+    const { width, height } = ctx;
+    const bg = ctx.settings.background === "black" ? "#000000" : "#ffffff";
+    const fg = ctx.settings.background === "black" ? "#ffffff" : "#000000";
+    const padX = 24;
+    const titleH = 64;
+    const rowCount = Math.max(1, data.events.length);
+    const rowH = (height - titleH - 24) / rowCount;
+
+    const rows = data.events
+      .map((ev, i) => {
+        const y = titleH + i * rowH;
+        const d = parseDate(ev.startTime);
+        const day = d ? String(d.getDate()).padStart(2, "0") : "—";
+        const mon = d ? d.toLocaleString("en-US", { month: "short" }).toUpperCase() : "";
+        const dow = d ? d.toLocaleString("en-US", { weekday: "short" }).toUpperCase() : "";
+        const time = d ? d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" }) : "";
+        const dateBoxW = 110;
+        return [
+          // Date stack on the left.
+          `<g transform="translate(${padX}, ${y + 8})">
+            <text x="${dateBoxW / 2}" y="22" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="22" fill="${fg}">${svgEscape(dow)}</text>
+            <text x="${dateBoxW / 2}" y="72" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="60" fill="${fg}">${svgEscape(day)}</text>
+            <text x="${dateBoxW / 2}" y="98" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-weight="400" font-size="20" fill="${fg}">${svgEscape(mon)}</text>
+          </g>`,
+          // Divider.
+          `<line x1="${padX + dateBoxW + 12}" y1="${y + 16}" x2="${padX + dateBoxW + 12}" y2="${y + rowH - 16}" stroke="${fg}" stroke-width="2"/>`,
+          // Title + subtitle.
+          `<text x="${padX + dateBoxW + 28}" y="${y + 42}" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="30" fill="${fg}">${svgEscape(ev.title)}</text>`,
+          ev.subtitle
+            ? `<text x="${padX + dateBoxW + 28}" y="${y + 74}" font-family="Helvetica, Arial, sans-serif" font-size="20" fill="${fg}">${svgEscape(ev.subtitle)}</text>`
+            : "",
+          `<text x="${padX + dateBoxW + 28}" y="${y + 104}" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="${fg}">${svgEscape([time, ev.location].filter(Boolean).join(" · "))}</text>`,
+        ].join("");
+      })
+      .join("");
+
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="${bg}"/>
+  <text x="${padX}" y="44" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="36" fill="${fg}">${svgEscape(ctx.settings.title)}</text>
+  ${rows}
+</svg>`;
+  },
+};
+
+function parseDate(s: string): Date | null {
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}

--- a/lib/plugins/types/kpi.ts
+++ b/lib/plugins/types/kpi.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { DataSourceConfig, fetchDataSource } from "../data-sources";
+import { svgEscape } from "../svg";
+
+const Settings = z.object({
+  dataSource: DataSourceConfig,
+  // JSON-pointer-ish dotted path into the fetched data to find the metric.
+  valuePath: z.string().default("value"),
+  label: z.string().default(""),
+  // Optional unit suffix, e.g. "lbs", "%".
+  unit: z.string().optional(),
+  // sprintf-lite: %d → toString, %.1f → 1 decimal, fallback "%s".
+  format: z.string().default("%s"),
+  // Background polarity. Park signs are usually black-on-white; we leave
+  // both options open so a designer can match the surrounding layout.
+  background: z.enum(["white", "black"]).default("white"),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { value: number | string };
+
+export const kpiPlugin: PluginType<Settings, Data> = {
+  id: "kpi",
+  name: "KPI",
+  description: "A big number with a label. Pulls one value from a data source and renders it large.",
+  category: "kpi",
+  defaultTtlSec: 900,
+  defaultSize: { w: 480, h: 320 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const raw = await fetchDataSource(ctx.settings.dataSource);
+    const value = lookup(raw, ctx.settings.valuePath);
+    return { value: (value as number | string) ?? "—" };
+  },
+
+  async renderSvg(ctx, data) {
+    const { width, height } = ctx;
+    const bg = ctx.settings.background === "black" ? "#000000" : "#ffffff";
+    const fg = ctx.settings.background === "black" ? "#ffffff" : "#000000";
+    const formatted = applyFormat(ctx.settings.format, data.value);
+    const display = `${formatted}${ctx.settings.unit ? ` ${ctx.settings.unit}` : ""}`;
+    // Big number occupies ~60% of height; label sits beneath at ~15%.
+    const numSize = Math.floor(height * 0.55);
+    const labelSize = Math.max(14, Math.floor(height * 0.10));
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="${bg}"/>
+  <text x="50%" y="55%" text-anchor="middle" dominant-baseline="middle"
+        font-family="Helvetica, Arial, sans-serif" font-weight="700"
+        font-size="${numSize}" fill="${fg}">${svgEscape(display)}</text>
+  <text x="50%" y="${height - Math.floor(height * 0.10)}" text-anchor="middle"
+        font-family="Helvetica, Arial, sans-serif" font-weight="400"
+        font-size="${labelSize}" fill="${fg}">${svgEscape(ctx.settings.label)}</text>
+</svg>`;
+  },
+};
+
+function lookup(obj: unknown, path: string): unknown {
+  const parts = path.split(".").filter(Boolean);
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[/^\d+$/.test(p) ? Number(p) : p];
+  }
+  return cur;
+}
+
+function applyFormat(fmt: string, value: number | string): string {
+  if (fmt === "%s" || fmt === "") return String(value);
+  if (fmt === "%d") return String(Math.round(Number(value)));
+  const float = fmt.match(/^%\.(\d+)f$/);
+  if (float) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n.toFixed(Number(float[1])) : String(value);
+  }
+  return String(value);
+}

--- a/lib/plugins/types/list.ts
+++ b/lib/plugins/types/list.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { DataSourceConfig, fetchDataSource } from "../data-sources";
+import { interpolate } from "../template";
+import { svgEscape } from "../svg";
+
+// A vertical or horizontal list. Authors supply a per-item SVG snippet
+// rendered once per record; the plugin handles the outer frame and
+// arrangement.
+
+const Settings = z.object({
+  dataSource: DataSourceConfig,
+  // Optional dotted path to the array within the response.
+  itemsPath: z.string().optional(),
+  // Per-item snippet — gets `{{item.field}}` access plus `{{i}}` index.
+  itemTemplate: z.string().default(`<text x="10" y="{{y}}" font-family="Helvetica" font-size="20" fill="black">{{item.title}}</text>`),
+  max: z.number().int().positive().default(5),
+  direction: z.enum(["vertical", "horizontal"]).default("vertical"),
+  title: z.string().optional(),
+  background: z.enum(["white", "black"]).default("white"),
+  padding: z.number().nonnegative().default(16),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { items: unknown[] };
+
+export const listPlugin: PluginType<Settings, Data> = {
+  id: "list",
+  name: "List",
+  description: "Iterate an array data source through a per-item SVG template. Good for upcoming events, recent observations, leaderboards.",
+  category: "list",
+  defaultTtlSec: 900,
+  defaultSize: { w: 480, h: 720 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const raw = await fetchDataSource(ctx.settings.dataSource);
+    let items = raw as unknown[];
+    if (ctx.settings.itemsPath) items = lookup(raw, ctx.settings.itemsPath) as unknown[];
+    if (!Array.isArray(items)) items = [];
+    return { items: items.slice(0, ctx.settings.max) };
+  },
+
+  async renderSvg(ctx, data) {
+    const { width, height } = ctx;
+    const bg = ctx.settings.background === "black" ? "#000000" : "#ffffff";
+    const fg = ctx.settings.background === "black" ? "#ffffff" : "#000000";
+    const pad = ctx.settings.padding;
+    const titleHeight = ctx.settings.title ? 48 : 0;
+    const innerW = width - pad * 2;
+    const innerH = height - pad * 2 - titleHeight;
+    const count = Math.max(1, data.items.length);
+    const slotW = ctx.settings.direction === "horizontal" ? Math.floor(innerW / count) : innerW;
+    const slotH = ctx.settings.direction === "horizontal" ? innerH : Math.floor(innerH / count);
+
+    const items = data.items
+      .map((item, i) => {
+        const x = pad + (ctx.settings.direction === "horizontal" ? i * slotW : 0);
+        const y = pad + titleHeight + (ctx.settings.direction === "vertical" ? i * slotH : 0);
+        const inner = interpolate(ctx.settings.itemTemplate, {
+          item,
+          i,
+          x,
+          y,
+          w: slotW,
+          h: slotH,
+          fg,
+          bg,
+        });
+        return `<g transform="translate(0,0)">${inner}</g>`;
+      })
+      .join("");
+
+    const titleSvg = ctx.settings.title
+      ? `<text x="${pad}" y="${pad + 32}" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="32" fill="${fg}">${svgEscape(ctx.settings.title)}</text>`
+      : "";
+
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="${bg}"/>
+  ${titleSvg}
+  ${items}
+</svg>`;
+  },
+};
+
+function lookup(obj: unknown, path: string): unknown {
+  const parts = path.split(".").filter(Boolean);
+  let cur: any = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[/^\d+$/.test(p) ? Number(p) : p];
+  }
+  return cur;
+}

--- a/lib/plugins/types/plant-heatmap.ts
+++ b/lib/plugins/types/plant-heatmap.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { recentPlantObservations, PlantObservation } from "../wildmile";
+import { svgEscape } from "../svg";
+
+// Density map: project plant observations onto a grid, draw filled cells
+// whose darkness encodes count. v1 uses a simple lat/lng bounding box —
+// later we can ingest a custom park outline as an SVG path.
+
+const Settings = z.object({
+  projectId: z.string().optional(),
+  sinceDays: z.number().int().positive().max(3650).default(365),
+  // Grid resolution.
+  cols: z.number().int().min(4).max(60).default(16),
+  rows: z.number().int().min(4).max(60).default(10),
+  // Optional manual bounds (decimal degrees). If unset, computed from data.
+  bounds: z
+    .object({
+      minLat: z.number(),
+      maxLat: z.number(),
+      minLng: z.number(),
+      maxLng: z.number(),
+    })
+    .optional(),
+  title: z.string().default("Plant observations"),
+  background: z.enum(["white", "black"]).default("white"),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = {
+  cells: { row: number; col: number; count: number }[];
+  max: number;
+  total: number;
+  bounds: { minLat: number; maxLat: number; minLng: number; maxLng: number };
+};
+
+export const plantHeatmapPlugin: PluginType<Settings, Data> = {
+  id: "plant-heatmap",
+  name: "Plant Heatmap",
+  description: "Density map of plant observations from the Wildmile MongoDB. Bins points into a grid and shades each cell by count.",
+  category: "data-viz",
+  defaultTtlSec: 3600,
+  defaultSize: { w: 960, h: 720 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const since = new Date(ctx.now.getTime() - ctx.settings.sinceDays * 86400_000);
+    const obs = await recentPlantObservations({
+      projectId: ctx.settings.projectId,
+      since,
+      limit: 5000,
+    });
+    return binToGrid(obs, ctx.settings);
+  },
+
+  async renderSvg(ctx, data) {
+    const { width, height } = ctx;
+    const bg = ctx.settings.background === "black" ? "#000000" : "#ffffff";
+    const fg = ctx.settings.background === "black" ? "#ffffff" : "#000000";
+    const titleH = 56;
+    const footerH = 28;
+    const innerW = width;
+    const innerH = height - titleH - footerH;
+    const cellW = innerW / ctx.settings.cols;
+    const cellH = innerH / ctx.settings.rows;
+    const max = Math.max(1, data.max);
+
+    const cells = data.cells
+      .map((c) => {
+        const x = c.col * cellW;
+        const y = titleH + c.row * cellH;
+        const intensity = c.count / max;
+        // Quantise to 5 levels so 1-bit dithering reads cleanly.
+        const level = Math.min(4, Math.floor(intensity * 5));
+        const opacity = (level + 1) / 5;
+        return `<rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${cellW.toFixed(2)}" height="${cellH.toFixed(2)}" fill="${fg}" fill-opacity="${opacity.toFixed(2)}"/>`;
+      })
+      .join("");
+
+    // Grid lines on top so cells stay visually segmented.
+    const verticals = Array.from({ length: ctx.settings.cols + 1 }, (_, i) => {
+      const x = i * cellW;
+      return `<line x1="${x.toFixed(2)}" y1="${titleH}" x2="${x.toFixed(2)}" y2="${titleH + innerH}" stroke="${fg}" stroke-opacity="0.25" stroke-width="1"/>`;
+    }).join("");
+    const horizontals = Array.from({ length: ctx.settings.rows + 1 }, (_, i) => {
+      const y = titleH + i * cellH;
+      return `<line x1="0" y1="${y.toFixed(2)}" x2="${innerW}" y2="${y.toFixed(2)}" stroke="${fg}" stroke-opacity="0.25" stroke-width="1"/>`;
+    }).join("");
+
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="${bg}"/>
+  <text x="24" y="40" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="32" fill="${fg}">${svgEscape(ctx.settings.title)}</text>
+  ${cells}
+  ${verticals}
+  ${horizontals}
+  <text x="${width - 24}" y="${height - 10}" text-anchor="end" font-family="Helvetica, Arial, sans-serif" font-size="14" fill="${fg}">${data.total} observations · darker = more</text>
+</svg>`;
+  },
+};
+
+function binToGrid(obs: PlantObservation[], s: Settings): Data {
+  const points = obs.filter((o): o is PlantObservation & { lat: number; lng: number } =>
+    typeof o.lat === "number" && typeof o.lng === "number"
+  );
+  if (points.length === 0) {
+    const b = s.bounds ?? { minLat: 0, maxLat: 1, minLng: 0, maxLng: 1 };
+    return { cells: [], max: 0, total: 0, bounds: b };
+  }
+  const bounds = s.bounds ?? {
+    minLat: Math.min(...points.map((p) => p.lat)),
+    maxLat: Math.max(...points.map((p) => p.lat)),
+    minLng: Math.min(...points.map((p) => p.lng)),
+    maxLng: Math.max(...points.map((p) => p.lng)),
+  };
+  // Guard against degenerate (zero-extent) bounds.
+  const dLat = Math.max(1e-9, bounds.maxLat - bounds.minLat);
+  const dLng = Math.max(1e-9, bounds.maxLng - bounds.minLng);
+  const counts = new Map<string, number>();
+  for (const p of points) {
+    const col = clamp(Math.floor(((p.lng - bounds.minLng) / dLng) * s.cols), 0, s.cols - 1);
+    // Y axis inverts — north (max lat) should be at the top.
+    const row = clamp(Math.floor(((bounds.maxLat - p.lat) / dLat) * s.rows), 0, s.rows - 1);
+    const k = `${row},${col}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  const cells = Array.from(counts.entries()).map(([k, count]) => {
+    const [row, col] = k.split(",").map(Number);
+    return { row, col, count };
+  });
+  const max = cells.reduce((m, c) => Math.max(m, c.count), 0);
+  return { cells, max, total: points.length, bounds };
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}

--- a/lib/plugins/types/trash-dashboard.ts
+++ b/lib/plugins/types/trash-dashboard.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type { PluginType } from "../types";
+import { trashCountsBy, TrashGroup } from "../wildmile";
+import { svgEscape } from "../svg";
+
+// Horizontal bar chart of trash counts. Designed for 1-bit output —
+// filled bars + black labels, no gradients.
+
+const Settings = z.object({
+  sinceDays: z.number().int().positive().max(3650).default(30),
+  groupBy: z.enum(["category", "material", "day"]).default("category"),
+  topN: z.number().int().positive().max(20).default(8),
+  title: z.string().default("Trash collected"),
+  background: z.enum(["white", "black"]).default("white"),
+});
+
+type Settings = z.infer<typeof Settings>;
+type Data = { groups: TrashGroup[]; total: number };
+
+export const trashDashboardPlugin: PluginType<Settings, Data> = {
+  id: "trash-dashboard",
+  name: "Trash Dashboard",
+  description: "Horizontal bar chart of trash counts from the Wildmile DB, grouped by category, material, or day.",
+  category: "data-viz",
+  defaultTtlSec: 3600,
+  defaultSize: { w: 960, h: 540 },
+  settingsSchema: Settings,
+
+  async fetchData(ctx) {
+    const since = new Date(ctx.now.getTime() - ctx.settings.sinceDays * 86400_000);
+    const groups = await trashCountsBy({
+      from: since,
+      to: ctx.now,
+      groupBy: ctx.settings.groupBy,
+      limit: ctx.settings.topN,
+    });
+    const total = groups.reduce((s, g) => s + g.count, 0);
+    return { groups, total };
+  },
+
+  async renderSvg(ctx, data) {
+    const { width, height } = ctx;
+    const bg = ctx.settings.background === "black" ? "#000000" : "#ffffff";
+    const fg = ctx.settings.background === "black" ? "#ffffff" : "#000000";
+    const padX = 24;
+    const titleH = 64;
+    const footerH = 32;
+    const innerH = height - titleH - footerH;
+    const rowCount = Math.max(1, data.groups.length);
+    const rowH = innerH / rowCount;
+    const labelW = Math.floor(width * 0.28);
+    const max = Math.max(1, data.groups.reduce((m, g) => Math.max(m, g.count), 0));
+    const barAreaW = width - padX * 2 - labelW;
+
+    const rows = data.groups
+      .map((g, i) => {
+        const y = titleH + i * rowH;
+        const barH = Math.max(8, rowH * 0.62);
+        const barY = y + (rowH - barH) / 2;
+        const barW = (g.count / max) * barAreaW;
+        return [
+          `<text x="${padX}" y="${barY + barH * 0.74}" font-family="Helvetica, Arial, sans-serif" font-size="${Math.floor(barH * 0.62)}" fill="${fg}">${svgEscape(g.label)}</text>`,
+          `<rect x="${padX + labelW}" y="${barY}" width="${barW.toFixed(2)}" height="${barH}" fill="${fg}"/>`,
+          `<text x="${padX + labelW + barW + 8}" y="${barY + barH * 0.74}" font-family="Helvetica, Arial, sans-serif" font-size="${Math.floor(barH * 0.62)}" fill="${fg}">${g.count}</text>`,
+        ].join("");
+      })
+      .join("");
+
+    return `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="${bg}"/>
+  <text x="${padX}" y="44" font-family="Helvetica, Arial, sans-serif" font-weight="700" font-size="36" fill="${fg}">${svgEscape(ctx.settings.title)}</text>
+  <text x="${width - padX}" y="44" text-anchor="end" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="${fg}">${data.total} items · last ${ctx.settings.sinceDays}d</text>
+  ${rows}
+</svg>`;
+  },
+};

--- a/lib/plugins/wildmile.ts
+++ b/lib/plugins/wildmile.ts
@@ -1,0 +1,168 @@
+import { MongoClient, Db } from "mongodb";
+import { z } from "zod";
+import { MongoWildmileSource } from "./data-sources";
+
+// Read-only connector to the upstream Wildmile MongoDB. We hold a separate
+// client so eink_cms's own DB pool is unaffected. The connection string
+// should belong to a user with read-only privileges on the relevant
+// collections — this module additionally enforces a collection allowlist.
+
+const URI = process.env.WILDMILE_MONGODB_URI;
+const DB_NAME = process.env.WILDMILE_MONGODB_DB || "wildmile";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var _wildmileClient: Promise<MongoClient> | undefined;
+}
+
+function clientPromise(): Promise<MongoClient> {
+  if (!URI) throw new Error("WILDMILE_MONGODB_URI is not set");
+  if (!global._wildmileClient) {
+    global._wildmileClient = new MongoClient(URI).connect();
+  }
+  return global._wildmileClient;
+}
+
+async function getWildmileDb(): Promise<Db> {
+  const client = await clientPromise();
+  return client.db(DB_NAME);
+}
+
+// Names mirror what the Wildmile repo's mongoose models compile to —
+// mongoose pluralises and lowercases by default. We expose the union here
+// rather than letting plugin authors pass arbitrary collection names so a
+// misconfigured plugin can't, say, read user accounts.
+export const ALLOWED_COLLECTIONS = [
+  "plants",
+  "individualplants",
+  "plantobservations",
+  "species",
+  "trashes",
+  "trashitems",
+  "individualtrashitems",
+  "trashitemmetadatas",
+  "events",
+  "projects",
+  "modules",
+  "sections",
+] as const;
+export type AllowedCollection = (typeof ALLOWED_COLLECTIONS)[number];
+
+function assertAllowed(name: string): asserts name is AllowedCollection {
+  if (!(ALLOWED_COLLECTIONS as readonly string[]).includes(name)) {
+    throw new Error(
+      `wildmile: collection "${name}" is not in the read allowlist`
+    );
+  }
+}
+
+// Generic query path used by the `mongo-wildmile` data-source.
+export async function wildmileQuery(
+  cfg: z.infer<typeof MongoWildmileSource>
+): Promise<unknown[]> {
+  assertAllowed(cfg.collection);
+  const db = await getWildmileDb();
+  let cursor = db
+    .collection(cfg.collection)
+    .find(cfg.query ?? {}, { projection: cfg.projection });
+  if (cfg.sort) cursor = cursor.sort(cfg.sort);
+  if (cfg.limit) cursor = cursor.limit(cfg.limit);
+  return cursor.toArray();
+}
+
+// Pre-baked helpers for the plant/trash/event plugins so they don't each
+// have to know the Wildmile schema by heart. Each returns plain serialisable
+// objects suitable for hashing and rendering.
+
+export async function recentPlantObservations(opts: {
+  projectId?: string;
+  since?: Date;
+  limit?: number;
+} = {}): Promise<PlantObservation[]> {
+  const db = await getWildmileDb();
+  const q: Record<string, unknown> = {};
+  if (opts.projectId) q.project = opts.projectId;
+  if (opts.since) q.createdAt = { $gte: opts.since };
+  const docs = await db
+    .collection("plantobservations")
+    .find(q)
+    .sort({ createdAt: -1 })
+    .limit(opts.limit ?? 1000)
+    .toArray();
+  return docs.map((d: any) => ({
+    id: String(d._id),
+    species: d.species ? String(d.species) : undefined,
+    lat: d.location?.coordinates?.[1] ?? d.lat,
+    lng: d.location?.coordinates?.[0] ?? d.lng,
+    createdAt: d.createdAt instanceof Date ? d.createdAt.toISOString() : undefined,
+  }));
+}
+
+export async function trashCountsBy(opts: {
+  from?: Date;
+  to?: Date;
+  groupBy?: "category" | "material" | "day";
+  limit?: number;
+} = {}): Promise<TrashGroup[]> {
+  const db = await getWildmileDb();
+  const match: Record<string, unknown> = {};
+  if (opts.from || opts.to) {
+    match.createdAt = {} as Record<string, unknown>;
+    if (opts.from) (match.createdAt as any).$gte = opts.from;
+    if (opts.to) (match.createdAt as any).$lte = opts.to;
+  }
+  const groupKey =
+    opts.groupBy === "day"
+      ? { $dateToString: { format: "%Y-%m-%d", date: "$createdAt" } }
+      : opts.groupBy === "material"
+        ? "$material"
+        : "$category";
+  const docs = await db
+    .collection("individualtrashitems")
+    .aggregate([
+      { $match: match },
+      { $group: { _id: groupKey, count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: opts.limit ?? 20 },
+    ])
+    .toArray();
+  return docs.map((d: any) => ({ label: String(d._id ?? "unknown"), count: Number(d.count) }));
+}
+
+export async function upcomingEvents(opts: { limit?: number } = {}): Promise<UpcomingEvent[]> {
+  const db = await getWildmileDb();
+  const now = new Date();
+  const docs = await db
+    .collection("events")
+    .find({ startTime: { $gte: now } } as Record<string, unknown>)
+    .sort({ startTime: 1 })
+    .limit(opts.limit ?? 10)
+    .toArray();
+  return docs.map((d: any) => ({
+    id: String(d._id),
+    title: d.title ?? d.name ?? "Event",
+    subtitle: d.subtitle ?? d.description ?? undefined,
+    startTime: d.startTime instanceof Date ? d.startTime.toISOString() : String(d.startTime ?? ""),
+    endTime: d.endTime instanceof Date ? d.endTime.toISOString() : (d.endTime ? String(d.endTime) : undefined),
+    location: d.location?.name ?? undefined,
+  }));
+}
+
+export type PlantObservation = {
+  id: string;
+  species?: string;
+  lat?: number;
+  lng?: number;
+  createdAt?: string;
+};
+
+export type TrashGroup = { label: string; count: number };
+
+export type UpcomingEvent = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  startTime: string;
+  endTime?: string;
+  location?: string;
+};

--- a/lib/render.ts
+++ b/lib/render.ts
@@ -7,6 +7,8 @@ import { ensureFontsRegistered, fontString } from "./fonts";
 import { renderQr } from "./qr";
 import { abbreviateDay, dayOfMonth, formatTimeParts, monthName, parseFlexible } from "./dates";
 import { editorDims } from "./dims";
+import { ensureFreshOutput } from "./plugins/runner";
+import { getMedia } from "./media";
 
 // ---- Rendering pipeline ----
 // 1) Draw everything onto an RGBA canvas at device pixel size.
@@ -153,6 +155,29 @@ async function drawBlock(
     case "shape":
       drawShape(ctx, block, fg);
       return;
+    case "plugin":
+      await drawPluginBlock(ctx, block);
+      return;
+  }
+}
+
+// Plugin output is a PNG cached in the media collection. We make sure it's
+// fresh (subject to the instance's TTL) and then draw it at the block's
+// position and size — same compositing path as drawImage.
+async function drawPluginBlock(ctx: SKRSContext2D, block: Block) {
+  if (!block.pluginInstanceId) return;
+  try {
+    const inst = await ensureFreshOutput(block.pluginInstanceId);
+    const mediaId = inst?.latestMediaId;
+    if (!mediaId) return;
+    const m = await getMedia(mediaId);
+    if (!m?.dataUrl) return;
+    const img = await loadImage(m.dataUrl);
+    // @ts-ignore
+    ctx.imageSmoothingEnabled = false;
+    ctx.drawImage(img, block.x, block.y, block.w, block.h);
+  } catch (e) {
+    console.error("plugin block render failed", block.pluginInstanceId, e);
   }
 }
 
@@ -194,7 +219,14 @@ async function drawImage(ctx: SKRSContext2D, block: Block, dctx: DrawCtx) {
   //   - a data: URL (user-uploaded 1-bit PNG)
   //   - a leading-slash path, resolved against ./public/ on disk
   //   - an http(s) URL (fetched by loadImage)
+  //
+  // Additionally, mediaId points at a MediaItem and wins over imageData
+  // when both are present. Existing data-URL blocks keep working.
   let src = block.imageData;
+  if (block.mediaId) {
+    const m = await getMedia(block.mediaId);
+    if (m?.dataUrl) src = m.dataUrl;
+  }
   if (src && src.startsWith("{{") && src.endsWith("}}")) {
     const key = src.slice(2, -2).trim();
     src = dctx.imageBindings?.[key] ?? dctx.bindings?.[key];

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    serverComponentsExternalPackages: ["@napi-rs/canvas", "mongodb"],
+    serverComponentsExternalPackages: ["@napi-rs/canvas", "mongodb", "@resvg/resvg-js", "@anthropic-ai/sdk"],
   },
   async headers() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "eink-cms",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.96.0",
         "@napi-rs/canvas": "^0.1.53",
+        "@resvg/resvg-js": "^2.6.2",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.1",
         "mongodb": "^6.9.0",
@@ -44,6 +46,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -530,6 +562,227 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -1048,6 +1301,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1250,6 +1509,19 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1990,6 +2262,16 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -2216,6 +2498,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.96.0",
     "@napi-rs/canvas": "^0.1.53",
+    "@resvg/resvg-js": "^2.6.2",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.1.1",
     "mongodb": "^6.9.0",
-    "qrcode": "^1.5.4",
     "next": "14.2.33",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary
- Adds a plugin system: code-defined TYPES (`lib/plugins/types/*.ts`) + DB-stored INSTANCES with TTL + data-hash caching. Output is SVG → PNG via `@resvg/resvg-js`, composited by a new `plugin` block through the existing 1-bit dither pipeline.
- Seven starter types: `custom-svg`, `kpi`, `list`, `plant-heatmap`, `trash-dashboard`, `events`, `claude-gen`. Read-only Wildmile Mongo connector with collection allowlist (`lib/plugins/wildmile.ts`).
- New CMS surfaces: `/plugins` (list / new / edit + force-refresh + preview), `/media` (uploads + generated outputs), `/layouts` (templates + apply-to-device), draft+publish on devices for staging before a sign goes live.

## Architecture
- TYPE: zod settings schema, `fetchData(ctx)`, `renderSvg(ctx, data)`. Registered statically in `lib/plugins/registry.ts` so Vercel bundling works.
- INSTANCE: Mongo doc with `typeId`, `settings`, `width`, `height`, `ttlSec`, `lastRunAt`, `lastDataHash`, `latestMediaId`, `lastError`.
- Regenerate-on-pull: device pulls `/<slug>/current.bmp`; \`drawPluginBlock\` calls \`ensureFreshOutput\` (TTL-gated, skips renderer if data hash unchanged), then loads the cached PNG from the media collection.
- Errors recorded on the instance — never thrown into the device pull path.

## New env vars
- \`WILDMILE_MONGODB_URI\` / \`WILDMILE_MONGODB_DB\` — read-only credentials recommended.
- \`ANTHROPIC_API_KEY\` — only needed for the \`claude-gen\` type.

## Test plan
- [x] \`npm run build\` clean
- [x] End-to-end browser smoke: create custom-svg instance → save settings → force refresh → \`/api/plugins/instances/<id>/preview.png\` returns rasterised SVG
- [x] Plugin block placed on a device → \`/<slug>/current.png\` composites plugin output (28 KB PNG returned)
- [ ] Point \`WILDMILE_MONGODB_URI\` at the real Wildmile DB and try \`plant-heatmap\` + \`trash-dashboard\` + \`events\`
- [ ] Set \`ANTHROPIC_API_KEY\` and try a \`claude-gen\` instance in text mode against a designer-authored SVG template

🤖 Generated with [Claude Code](https://claude.com/claude-code)